### PR TITLE
`Toggle`, `Variant`, and `Payload` properties are public

### DIFF
--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -9,21 +9,21 @@ struct FeatureResponse: Codable {
 
 // MARK: - Toggle
 public struct Toggle: Codable {
-    let name: String
-    let enabled: Bool
-    let variant: Variant
+    public let name: String
+    public let enabled: Bool
+    public let variant: Variant
 }
 
 // MARK: - Variant
 public struct Variant: Codable {
-    let name: String
-    let enabled: Bool
-    let payload: Payload?
+    public let name: String
+    public let enabled: Bool
+    public let payload: Payload?
 }
 
 // MARK: - Payload
 public struct Payload: Codable {
-    let type, value: String
+    public let type, value: String
 }
 
 struct Context {


### PR DESCRIPTION
`Toggle`, `Variant`, and `Payload` structs are `public`, but their properties are not. This means that the properties can't be referenced from outside the framework, so for example this code snippet won't compile.

```
var variant = unleash.getVariant(name: "ios")
if variant.enabled {
    // do something
} else {
   // do something else
}
```

This PR marks the properties as `public`, so that these properties can be referenced outside the framework.