### PR TITLE
Allow case insensitive etag header

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -90,8 +90,8 @@ public class Poller {
                 if httpResponse.statusCode == 200 {
                     var result: FeatureResponse?
                     
-                    if httpResponse.allHeaderFields["Etag"] as! String != "" {
-                        self.etag = httpResponse.allHeaderFields["Etag"] as! String
+                    if let etag = httpResponse.value(forHTTPHeaderField: "Etag"), !etag.isEmpty {
+                        self.etag = etag
                     }
                     
                     do {

--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -2,6 +2,9 @@
 import Foundation
 import SwiftEventBus
 
+public protocol PollerSession {
+    func perform(_ request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void)
+}
 
 public class Poller {
     var refreshInterval: Int?
@@ -12,7 +15,9 @@ public class Poller {
     var apiKey: String;
     var etag: String;
     
-    public init(refreshInterval: Int? = nil, unleashUrl: String, apiKey: String) {
+    private let session: PollerSession
+    
+    public init(refreshInterval: Int? = nil, unleashUrl: String, apiKey: String, session: PollerSession = URLSession.shared) {
         self.refreshInterval = refreshInterval
         self.unleashUrl = unleashUrl
         self.apiKey = apiKey
@@ -20,6 +25,7 @@ public class Poller {
         self.toggles = [:]
         self.ready = false
         self.etag = ""
+        self.session = session
    }
     
     public func start(context: [String: String]) -> Void {
@@ -69,8 +75,7 @@ public class Poller {
         request.setValue(self.etag, forHTTPHeaderField: "If-None-Match")
         request.cachePolicy = .reloadIgnoringLocalCacheData
         
-        
-        URLSession.shared.dataTask(with: request, completionHandler: { (data, response, error) in
+        session.perform(request, completionHandler: { (data, response, error) in
             guard let data = data, error == nil else {
                 print("Something went wrong")
                 return
@@ -113,7 +118,7 @@ public class Poller {
                     }
                 }
             }
-        }).resume()
+        })
     }
 }
 

--- a/Sources/UnleashProxyClientSwift/URLSession+Extensions.swift
+++ b/Sources/UnleashProxyClientSwift/URLSession+Extensions.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension URLSession: PollerSession {
+    public func perform(_ request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
+        let task = dataTask(with: request) { (data, response, error) in
+            completionHandler(data, response, error)
+        }
+        task.resume()
+    }
+}

--- a/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
@@ -8,12 +8,28 @@
 import Foundation
 @testable import UnleashProxyClientSwift
 
+class MockPollerSession: PollerSession {
+    var data: Data?
+    var response: URLResponse?
+    var error: Error?
+
+    init(data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) {
+        self.data = data
+        self.response = response
+        self.error = error
+    }
+
+    func perform(_ request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
+        completionHandler(data, response, error)
+    }
+}
+
 class MockPoller: Poller {
     var dataGenerator: () -> [String: Toggle];
     
-    init(callback: @escaping () -> [String: Toggle], unleashUrl: String, apiKey: String ) {
+    init(callback: @escaping () -> [String: Toggle], unleashUrl: String, apiKey: String, session: PollerSession) {
         self.dataGenerator = callback
-        super.init(refreshInterval: 15, unleashUrl: unleashUrl, apiKey: apiKey)
+        super.init(refreshInterval: 15, unleashUrl: unleashUrl, apiKey: apiKey, session: session)
     }
     
     override func getFeatures(context: [String: String]) -> Void {

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import UnleashProxyClientSwift
+
+final class PollerTests: XCTestCase {
+
+    private let unleashUrl = "https://app.unleash-hosted.com/hosted/api/proxy"
+    private let apiKey = "SECRET"
+
+    func testTitleCaseEtagResponseHeader() {
+        let response = mockResponse(headerFields: ["Etag": "W/\"77f-WboeNIYTrCbEJ+TK78VuhInQn2M\""])
+        let data = stubData()
+        let session = MockPollerSession(data: data, response: response)
+        let poller = createPoller(with: session)
+
+        XCTAssertTrue(poller.etag.isEmpty)
+        poller.getFeatures(context: [:])
+        XCTAssertEqual(poller.etag, "W/\"77f-WboeNIYTrCbEJ+TK78VuhInQn2M\"")
+    }
+
+    func testLowerCaseEtagResponseHeader() {
+        let response = mockResponse(headerFields: ["etag": "W/\"710-wJiNH+MQpj0ruMo7n/9j36tB+Fg\""])
+        let data = stubData()
+        let session = MockPollerSession(data: data, response: response)
+        let poller = createPoller(with: session)
+
+        XCTAssertTrue(poller.etag.isEmpty)
+        poller.getFeatures(context: [:])
+        XCTAssertEqual(poller.etag, "W/\"710-wJiNH+MQpj0ruMo7n/9j36tB+Fg\"")
+    }
+
+    func testEmptyEtagResponseHeader() {
+        let response = mockResponse(headerFields: ["Etag": ""])
+        let data = stubData()
+        let session = MockPollerSession(data: data, response: response)
+        let poller = createPoller(with: session)
+        poller.etag = "W/\"7c-GUwjw43L+nPpd9TY5PHtsXJueiM\""
+
+        XCTAssertEqual(poller.etag, "W/\"7c-GUwjw43L+nPpd9TY5PHtsXJueiM\"")
+        poller.getFeatures(context: [:])
+        XCTAssertEqual(poller.etag, "W/\"7c-GUwjw43L+nPpd9TY5PHtsXJueiM\"")
+    }
+
+    private func createPoller(with session: PollerSession) -> Poller {
+        return Poller(refreshInterval: nil, unleashUrl: unleashUrl, apiKey: apiKey, session: session)
+    }
+
+    private func mockResponse(statusCode: Int = 200, headerFields: [String : String]? = nil) -> URLResponse {
+        return HTTPURLResponse(url: URL(string: unleashUrl)!, statusCode: statusCode, httpVersion: nil, headerFields: headerFields)!
+    }
+
+    private func stubData() -> Data {
+        let stub: [String: Any] = [
+            "toggles": [
+                [ "name": "foo", "enabled": true ],
+                [ "name": "bar", "enabled": false ]
+            ]
+        ]
+        return try! JSONSerialization.data(withJSONObject: stub, options: .prettyPrinted)
+    }
+}

--- a/Tests/UnleashProxyClientSwiftTests/testUtils.swift
+++ b/Tests/UnleashProxyClientSwiftTests/testUtils.swift
@@ -31,8 +31,8 @@ func generateTestToggleMapWithVariant() -> [String: Toggle] {
     return toggleMap
 }
 
-func setup(dataGenerator: @escaping () -> [String: Toggle]) -> UnleashClient {
-    let poller = MockPoller(callback: dataGenerator, unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", apiKey: "SECRET")
+func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) -> UnleashClient {
+    let poller = MockPoller(callback: dataGenerator, unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", apiKey: "SECRET", session: session)
     
     let unleash = UnleashProxyClientSwift.UnleashClient(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller)
     


### PR DESCRIPTION
Hey @FredrikOseberg, I wonder if you can help. We currently use Unleash for our internal feature flags and are investigating the new Unleash Swift Proxy Client. We currently run our own Unleash proxy but the new SDK crashes when it accesses the etag header as it is accessed strictly in the title-case form `Etag` and force cast to a string. The Unleash Android Proxy SDK uses the okhttp library which manages the caching and gets the Etag in a case-insensitive manner, shown here: https://github.com/square/okhttp/blob/f8fd4d08decf697013008b05ad7d2be10a648358/okhttp/src/main/kotlin/okhttp3/internal/cache/CacheStrategy.kt#L117.

I’ve raised a small PR which makes the Swift Etag response header accessor case-insensitive and doesn’t require the string casting step, apple Swift docs: https://developer.apple.com/documentation/foundation/nsurlrequest/1409376-value.

The current testing approach overrides the `func getFeatures(context: [String: String]) -> Void` which means it’s not possible to test the Poller networking or response logic. My second commit allows us to inject a URLSession which is defaulted to `URLSession.default` to match the current implementation and not force any interface changes. With this change we can fully test the Poller and provide mock response data and headers. I’ve only covered the changes I’ve introduced around etag header access but if this change is acceptable to you then you could also provide mocking for your other unit tests in the same way, and also test the other possible HTTP response codes.

## Issue
If an etag response header is returned with a lower case naming convention `etag` then the SDK crashes.
https://github.com/Unleash/unleash-proxy-client-swift/blob/6a56c35ce1ef9ea1bece778d9e9a938dd62a0692/Sources/UnleashProxyClientSwift/Poller.swift#L93