### PR TITLE
feat: add optional completion handler to poller start

### DIFF
--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -37,7 +37,7 @@ public class UnleashClient: ObservableObject {
     public var context: [String: String] = [:]
     var timer: Timer?
     var poller: Poller
-    
+
     public init(unleashUrl: String, clientKey: String, refreshInterval: Int? = nil, appName: String? = nil, environment: String? = nil, poller: Poller? = nil) {
         self.context["appName"] = appName
         self.context["environment"] = environment
@@ -47,40 +47,40 @@ public class UnleashClient: ObservableObject {
         } else {
             self.poller = Poller(refreshInterval: refreshInterval, unleashUrl: unleashUrl, apiKey: clientKey)
         }
-     
+
    }
-    
-    public func start() -> Void {
-        poller.start(context: context)
+
+    public func start(completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
+        poller.start(context: context, completionHandler: completionHandler)
     }
-    
+
     public func stop() -> Void {
         poller.stop()
     }
-    
+
     public func isEnabled(name: String) -> Bool {
         return poller.toggles[name]?.enabled ?? false
     }
-    
+
     public func getVariant(name: String) -> Variant {
         return poller.toggles[name]?.variant ?? Variant(name: "disabled", enabled: false, payload: nil)
     }
-    
+
     public func subscribe(name: String, callback: @escaping () -> Void) {
         SwiftEventBus.onBackgroundThread(self, name: name) { result in
             callback()
         }
     }
-    
+
     public func updateContext(context: [String: String]) -> Void {
         var newContext: [String: String] = [:]
         newContext["appName"] = self.context["appName"]
         newContext["environment"] = self.context["environment"]
-        
+
         context.forEach { (key, value) in
             newContext[key] = value
         }
-        
+
         self.context = newContext
         self.stop()
         self.start()

--- a/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
@@ -32,7 +32,7 @@ class MockPoller: Poller {
         super.init(refreshInterval: 15, unleashUrl: unleashUrl, apiKey: apiKey, session: session)
     }
     
-    override func getFeatures(context: [String: String]) -> Void {
+    override func getFeatures(context: [String: String], completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
         self.toggles = dataGenerator()
     }
 }


### PR DESCRIPTION
Hi @FredrikOseberg, I hope this finds you well. 

At present it is not possible for us to determine if the Unleash client has failed on the initial feature fetch. So I’ve raised this PR to allow users to optionally supply a completion handler on start, so we can be confident that at least the initial load of features was successful.

The completion handler is only called on the initial fetch and not on the following schedule timer fetches. I’ve unit tested the changes and included a `PollerError` type should consumers want to take action when the request fails on start. The completion handler is not a required argument and so shouldn’t break the current API.

I hope this makes sense but if you have feedback or an alternative approach I’ll be happy to help get this implemented.

Many thanks,

Elliott