### PR TITLE
Swap iOS 13 value(forHTTPHeaderField: ) Function to use allHeaderFields Dictionary

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -100,7 +100,7 @@ public class Poller {
                 if httpResponse.statusCode == 200 {
                     var result: FeatureResponse?
                     
-                    if let etag = httpResponse.value(forHTTPHeaderField: "Etag"), !etag.isEmpty {
+                    if let etag = httpResponse.allHeaderFields["Etag"] as? String, !etag.isEmpty {
                         self.etag = etag
                     }
                     


### PR DESCRIPTION
This _should_ resolve one of the two compile-time errors for projects with deployment targets below iOS 13, as mentioned in #11. Please correct me if I am wrong 🙂 