### PR TITLE
Revert "Add support for tvOS and watchOS"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,6 @@ let package = Package(
     platforms: [
         .macOS(.v10_15),
         .iOS(.v13),
-        .watchOS(.v6),
-        .tvOS(.v13)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ The unleash-proxy-client-swift will then cache these toggles in a map in memory 
 ## Requirements
 - MacOS: 12.15
 - iOS: 13
-- tvOS: 13
-- watchOS: 6
 
 ## Installation
 Follow the following steps in order to install the unleash-proxy-client-swift:

--- a/UnleashProxyClientSwift.podspec
+++ b/UnleashProxyClientSwift.podspec
@@ -6,7 +6,7 @@ spec.homepage     = "https://www.getunleash.io"
 spec.license      = { :type => "MIT", :file => "LICENSE" }
 spec.author             = { "author" => "fredrik@getunleash.io" }
 spec.documentation_url = "https://docs.getunleash.io/sdks/proxy-ios"
-spec.platforms = { :ios => "13.0", :osx => "10.15", :tvos => "13.0", :watchos => "6.0"  }
+spec.platforms = { :ios => "13.0", :osx => "10.15" }
 spec.swift_version = "5.1"
 spec.source       = { :git => "https://github.com/Unleash/unleash-proxy-client-swift.git", :tag => "#{spec.version}" }
 spec.source_files  = "Sources/UnleashProxyClientSwift/**/*.swift"


### PR DESCRIPTION
Reverts Unleash/unleash-proxy-client-swift#18

PR breaks the build, (more info in https://github.com/Unleash/unleash-proxy-client-swift/issues/21) and as a result we can't release the changes. Rolling this back until this can be tackled