### PR TITLE
feat: not return error when getting HTTP 204 no content responses

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -7,7 +7,6 @@ public protocol PollerSession {
 }
 
 public enum PollerError: Error {
-    case data
     case decoding
     case network
     case url
@@ -78,12 +77,6 @@ public class Poller {
         request.cachePolicy = .reloadIgnoringLocalCacheData
         
         session.perform(request, completionHandler: { (data, response, error) in
-            guard let data = data, error == nil else {
-                completionHandler?(.data)
-                print("Something went wrong")
-                return
-            }
-            
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 304 {
                     completionHandler?(nil)
@@ -94,6 +87,12 @@ public class Poller {
                 if httpResponse.statusCode > 399 && httpResponse.statusCode < 599 {
                     completionHandler?(.network)
                     print("Error fetching toggles")
+                    return
+                }
+                
+                guard let data = data else {
+                    completionHandler?(nil)
+                    print("No response data")
                     return
                 }
                 
@@ -122,7 +121,7 @@ public class Poller {
                         SwiftEventBus.post("ready")
                         self.ready = true
                     }
-
+                    
                     completionHandler?(nil)
                 }
             }

--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -7,6 +7,7 @@ public protocol PollerSession {
 }
 
 public enum PollerError: Error {
+    case response
     case data
     case decoding
     case network
@@ -78,54 +79,62 @@ public class Poller {
         request.cachePolicy = .reloadIgnoringLocalCacheData
         
         session.perform(request, completionHandler: { (data, response, error) in
-            guard let data = data, error == nil else {
+            guard let httpResponse = response as? HTTPURLResponse, error == nil else {
+                completionHandler?(.response)
+                print("Something went wrong")
+                return
+            }
+            
+            if httpResponse.statusCode == 304 {
+                completionHandler?(nil)
+                print("No changes in feature toggles.")
+                return
+            }
+            
+            if httpResponse.statusCode == 204 {
+                completionHandler?(nil)
+                print("Cached feature toggles on clients")
+                return
+            }
+            
+            if httpResponse.statusCode > 399 && httpResponse.statusCode < 599 {
+                completionHandler?(.network)
+                print("Error fetching toggles")
+                return
+            }
+            
+            guard let data = data, httpResponse.statusCode == 200 else {
                 completionHandler?(.data)
                 print("Something went wrong")
                 return
             }
             
-            if let httpResponse = response as? HTTPURLResponse {
-                if httpResponse.statusCode == 304 {
-                    completionHandler?(nil)
-                    print("No changes in feature toggles.")
-                    return
-                }
-                
-                if httpResponse.statusCode > 399 && httpResponse.statusCode < 599 {
-                    completionHandler?(.network)
-                    print("Error fetching toggles")
-                    return
-                }
-                
-                if httpResponse.statusCode == 200 {
-                    var result: FeatureResponse?
-                    
-                    if let etag = httpResponse.allHeaderFields["Etag"] as? String, !etag.isEmpty {
-                        self.etag = etag
-                    }
-                    
-                    do {
-                        result = try JSONDecoder().decode(FeatureResponse.self, from: data)
-                    } catch {
-                        print(error.localizedDescription)
-                    }
-                    
-                    guard let json = result else {
-                        completionHandler?(.decoding)
-                        return
-                    }
-                    
-                    self.toggles = self.createFeatureMap(features: json)
-                    if (self.ready) {
-                        SwiftEventBus.post("update")
-                    } else {
-                        SwiftEventBus.post("ready")
-                        self.ready = true
-                    }
-
-                    completionHandler?(nil)
-                }
+            var result: FeatureResponse?
+            
+            if let etag = httpResponse.allHeaderFields["Etag"] as? String, !etag.isEmpty {
+                self.etag = etag
             }
+            
+            do {
+                result = try JSONDecoder().decode(FeatureResponse.self, from: data)
+            } catch {
+                print(error.localizedDescription)
+            }
+            
+            guard let json = result else {
+                completionHandler?(.decoding)
+                return
+            }
+            
+            self.toggles = self.createFeatureMap(features: json)
+            if (self.ready) {
+                SwiftEventBus.post("update")
+            } else {
+                SwiftEventBus.post("ready")
+                self.ready = true
+            }
+            
+            completionHandler?(nil)
         })
     }
 }

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -54,13 +54,13 @@ final class PollerTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
-    func testStartCompletesWithDataError() {
+    func testStartCompletesWithoutErrorWhenDataEmpty() {
         let response = mockResponse()
         let session = MockPollerSession(data: nil, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect .data PollerError.")
         poller.start(context: [:]) { error in
-            XCTAssertEqual(error, .data)
+            XCTAssertNil(error)
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import UnleashProxyClientSwift
 
 final class PollerTests: XCTestCase {
-    
+
     private let unleashUrl = "https://app.unleash-hosted.com/hosted/api/proxy"
     private let apiKey = "SECRET"
     private let timeout = 1.0

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import UnleashProxyClientSwift
 
 final class PollerTests: XCTestCase {
-
+    
     private let unleashUrl = "https://app.unleash-hosted.com/hosted/api/proxy"
     private let apiKey = "SECRET"
     private let timeout = 1.0
@@ -54,6 +54,17 @@ final class PollerTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
+    func testStartCompletesWithResponseError() {
+        let session = MockPollerSession(data: nil, response: nil)
+        let poller = createPoller(with: session)
+        let expectation = XCTestExpectation(description: "Expect .response PollerError.")
+        poller.start(context: [:]) { error in
+            XCTAssertEqual(error, .response)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: timeout)
+    }
+
     func testStartCompletesWithDataError() {
         let response = mockResponse()
         let session = MockPollerSession(data: nil, response: response)
@@ -68,6 +79,19 @@ final class PollerTests: XCTestCase {
 
     func testStartCompletesWithoutErrorWhenResponseNotModified() {
         let response = mockResponse(statusCode: 304)
+        let data = stubData()
+        let session = MockPollerSession(data: data, response: response)
+        let poller = createPoller(with: session)
+        let expectation = XCTestExpectation(description: "Expect error to be nil.")
+        poller.start(context: [:]) { error in
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    func testStartCompletesWithoutErrorWhenResponseNoContent() {
+        let response = mockResponse(statusCode: 204)
         let data = stubData()
         let session = MockPollerSession(data: data, response: response)
         let poller = createPoller(with: session)

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -54,17 +54,6 @@ final class PollerTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
-    func testStartCompletesWithResponseError() {
-        let session = MockPollerSession(data: nil, response: nil)
-        let poller = createPoller(with: session)
-        let expectation = XCTestExpectation(description: "Expect .response PollerError.")
-        poller.start(context: [:]) { error in
-            XCTAssertEqual(error, .response)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: timeout)
-    }
-
     func testStartCompletesWithDataError() {
         let response = mockResponse()
         let session = MockPollerSession(data: nil, response: response)
@@ -79,19 +68,6 @@ final class PollerTests: XCTestCase {
 
     func testStartCompletesWithoutErrorWhenResponseNotModified() {
         let response = mockResponse(statusCode: 304)
-        let data = stubData()
-        let session = MockPollerSession(data: data, response: response)
-        let poller = createPoller(with: session)
-        let expectation = XCTestExpectation(description: "Expect error to be nil.")
-        poller.start(context: [:]) { error in
-            XCTAssertNil(error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: timeout)
-    }
-
-    func testStartCompletesWithoutErrorWhenResponseNoContent() {
-        let response = mockResponse(statusCode: 204)
         let data = stubData()
         let session = MockPollerSession(data: data, response: response)
         let poller = createPoller(with: session)


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

Hello @FredrikOseberg @sighphyre, hope you are doing well.

We have got `PollerError.data` when starting the poller intermittently due to getting HTTP 204 no content responses from the feature flag proxy. 

The mechanism on our web server is basically the first time a client makes a request to the server it returns an etag header which is a hash of the resource content. In order to save bandwidth on following requests it will compare this hash to see if any content has changed and if not the web server does not resend a full response as the client already has a copy cached from the first request. The SDK throws `data` error when the response is 204 no content in `func start(completionHandler: ((PollerError?) -> Void)? = nil) -> Void`.

This PR treats 204s response as successful requests by adding a checker in the session response. I hope this makes sense for you and please feel free to let me know any feedback or recommended approaches for this case.

Thanks a lot.

Mickey