### PR TITLE
Prevent undesired console logs

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -65,7 +65,7 @@ public class Poller {
     func getFeatures(context: [String: String], completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
         guard let url = URL(string: formatURL(context: context)) else {
             completionHandler?(.url)
-            print("Invalid URL")
+            Printer.printMessage("Invalid URL")
             return
         }
         
@@ -80,19 +80,19 @@ public class Poller {
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 304 {
                     completionHandler?(nil)
-                    print("No changes in feature toggles.")
+                    Printer.printMessage("No changes in feature toggles.")
                     return
                 }
                 
                 if httpResponse.statusCode > 399 && httpResponse.statusCode < 599 {
                     completionHandler?(.network)
-                    print("Error fetching toggles")
+                    Printer.printMessage("Error fetching toggles")
                     return
                 }
                 
                 guard let data = data else {
                     completionHandler?(nil)
-                    print("No response data")
+                    Printer.printMessage("No response data")
                     return
                 }
                 
@@ -106,7 +106,7 @@ public class Poller {
                     do {
                         result = try JSONDecoder().decode(FeatureResponse.self, from: data)
                     } catch {
-                        print(error.localizedDescription)
+                        Printer.printMessage(error.localizedDescription)
                     }
                     
                     guard let json = result else {

--- a/Sources/UnleashProxyClientSwift/Printer.swift
+++ b/Sources/UnleashProxyClientSwift/Printer.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  
+//
+//  Created by Daniel Chick on 11/2/22.
+//
+
+import Foundation
+
+class Printer {
+    static var showPrintStatements = false
+    static func printMessage(_ items: Any..., separator: String = " ", terminator: String = "\n") {
+        if showPrintStatements {
+            print(items, separator: separator, terminator: terminator)
+        }
+    }
+}

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -50,7 +50,8 @@ public class UnleashClient: ObservableObject {
 
    }
 
-    public func start(completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
+    public func start(_ printToConsole: Bool = false, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
+        Printer.showPrintStatements = printToConsole
         poller.start(context: context, completionHandler: completionHandler)
     }
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
When working with this SDK I noticed a lot of clutter in the console so I wrote this simple wrapper class to hide them if desired (and to prevent console printing in production builds).

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
`Printer.swift` is new and manages a boolean flag for whether or not to show print statements as well as the wrapper function for `print()`.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
While this is a non-ideal and temporary solution, it gets the job done. In the long term, I believe the SDK needs a protocol that consumers can subscribe to receive error callbacks if they choose to so they can be logged by their own services.
