### PR TITLE
feat: custom properties support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ unleash.updateContext(context: context)
 
 This will stop and start the polling interval in order to renew polling with new context values.
 
+You can use any of the [predefined fields](https://docs.getunleash.io/reference/unleash-context#structure). If you need to support
+[custom properties](https://docs.getunleash.io/reference/unleash-context#the-properties-field) pass them as the second argument:
+```swift
+var context: [String: String] = [:]
+context["userId"] = "c3b155b0-5ebe-4a20-8386-e0cab160051e"
+var properties: [String: String] = [:]
+properties["customKey"] = "customValue";
+unleash.updateContext(context: context, properties: properties)
+```
+
 ## Events
 
 The proxy client emits events that you can subscribe to. The following events are available:

--- a/Sources/UnleashProxyClientSwift/Context.swift
+++ b/Sources/UnleashProxyClientSwift/Context.swift
@@ -1,0 +1,47 @@
+public struct Context {
+    let appName: String?
+    let environment: String?
+    var userId: String?
+    var sessionId: String?
+    var remoteAddress: String?
+    var properties: [String: String]?
+    
+    init(
+        appName: String? = nil,
+        environment: String? = nil,
+        userId: String? = nil,
+        sessionId: String? = nil,
+        remoteAddress: String? = nil,
+        properties: [String: String]? = nil
+    ) {
+        self.appName = appName
+        self.environment = environment
+        self.userId = userId
+        self.sessionId = sessionId
+        self.remoteAddress = remoteAddress
+        self.properties = properties
+    }
+    
+    func toMap() -> [String: String] {
+        var params: [String: String] = [:]
+        if let userId = self.userId {
+            params["userId"] = userId
+        }
+        if let remoteAddress = self.remoteAddress {
+            params["remoteAddress"] = remoteAddress
+        }
+        if let sessionId = self.sessionId {
+            params["sessionId"] = sessionId
+        }
+        if let appName = self.appName {
+            params["appName"] = appName
+        }
+        if let environment = self.environment {
+            params["environment"] = environment
+        }
+        properties?.forEach { (key, value) in
+            params["properties[\(key)]"] = value
+        }
+        return params
+    }
+}

--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -34,7 +34,7 @@ public class Poller {
         self.session = session
     }
 
-    public func start(context: [String: String], completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
+    public func start(context: Context, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
         self.getFeatures(context: context, completionHandler: completionHandler)
 
         let timer = Timer.scheduledTimer(withTimeInterval: Double(self.refreshInterval ?? 15), repeats: true) { timer in
@@ -48,9 +48,9 @@ public class Poller {
         self.timer?.invalidate()
     }
 
-    func formatURL(context: [String: String]) -> URL? {
+    func formatURL(context: Context) -> URL? {
         var components = URLComponents(url: unleashUrl, resolvingAgainstBaseURL: false)
-        components?.queryItems = context.map { key, value in
+        components?.queryItems = context.toMap().map { key, value in
             URLQueryItem(name: key, value: value)
         }
 
@@ -65,7 +65,7 @@ public class Poller {
         }
     }
     
-    func getFeatures(context: [String: String], completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
+    func getFeatures(context: Context, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
         guard let url = formatURL(context: context) else {
             completionHandler?(.url)
             Printer.printMessage("Invalid URL")

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -25,15 +25,10 @@ public struct Payload: Codable {
     public let type, value: String
 }
 
-struct Context {
-    let appName: String?
-    let environment: String?
-}
-
 
 @available(macOS 10.15, *)
 public class UnleashClientBase {
-    public var context: [String: String] = [:]
+    var context: Context
     var timer: Timer?
     var poller: Poller
     var metrics: Metrics
@@ -43,8 +38,8 @@ public class UnleashClientBase {
             fatalError("Invalid Unleash URL: \(unleashUrl)")
         }
 
-        self.context["appName"] = appName
-        self.context["environment"] = environment
+        self.context = Context(appName: appName, environment: environment, properties: [:])
+
         self.timer = nil
         if let poller = poller {
             self.poller = poller
@@ -99,14 +94,15 @@ public class UnleashClientBase {
         }
     }
 
-    public func updateContext(context: [String: String]) -> Void {
-        var newContext: [String: String] = [:]
-        newContext["appName"] = self.context["appName"]
-        newContext["environment"] = self.context["environment"]
-
-        context.forEach { (key, value) in
-            newContext[key] = value
-        }
+    public func updateContext(context: [String: String], properties: [String:String]? = nil) -> Void {
+        var newContext = Context(
+            appName: self.context.appName,
+            environment: self.context.environment,
+            userId: context["userId"],
+            sessionId: context["sessionId"],
+            remoteAddress: context["remoteAddress"],
+            properties: properties
+        )
 
         self.context = newContext
         self.stop()

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -38,7 +38,7 @@ public class UnleashClientBase {
             fatalError("Invalid Unleash URL: \(unleashUrl)")
         }
 
-        self.context = Context(appName: appName, environment: environment, properties: [:])
+        self.context = Context(appName: appName, environment: environment)
 
         self.timer = nil
         if let poller = poller {
@@ -95,7 +95,20 @@ public class UnleashClientBase {
     }
 
     public func updateContext(context: [String: String], properties: [String:String]? = nil) -> Void {
-        var newContext = Context(
+        let specialKeys: Set = ["appName", "environment", "userId", "sessionId", "remoteAddress"]
+        var newProperties: [String: String] = [:]
+
+        context.forEach { (key, value) in
+            if !specialKeys.contains(key) {
+                newProperties[key] = value
+            }
+        }
+
+        properties?.forEach { (key, value) in
+            newProperties[key] = value
+        }
+        
+        let newContext = Context(
             appName: self.context.appName,
             environment: self.context.environment,
             userId: context["userId"],

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -28,7 +28,7 @@ public struct Payload: Codable {
 
 @available(macOS 10.15, *)
 public class UnleashClientBase {
-    var context: Context
+    public var context: Context
     var timer: Timer?
     var poller: Poller
     var metrics: Metrics
@@ -114,7 +114,7 @@ public class UnleashClientBase {
             userId: context["userId"],
             sessionId: context["sessionId"],
             remoteAddress: context["remoteAddress"],
-            properties: properties
+            properties: newProperties
         )
 
         self.context = newContext

--- a/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
@@ -32,7 +32,7 @@ class MockPoller: Poller {
         super.init(refreshInterval: 15, unleashUrl: unleashUrl, apiKey: apiKey, session: session)
     }
     
-    override func getFeatures(context: [String: String], completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
+    override func getFeatures(context: Context, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
         self.toggles = dataGenerator()
     }
 }

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -14,7 +14,7 @@ final class PollerTests: XCTestCase {
         let poller = createPoller(with: session)
 
         XCTAssertTrue(poller.etag.isEmpty)
-        poller.getFeatures(context: [:])
+        poller.getFeatures(context: Context())
         XCTAssertEqual(poller.etag, "W/\"77f-WboeNIYTrCbEJ+TK78VuhInQn2M\"")
     }
 
@@ -25,7 +25,7 @@ final class PollerTests: XCTestCase {
         let poller = createPoller(with: session)
 
         XCTAssertTrue(poller.etag.isEmpty)
-        poller.getFeatures(context: [:])
+        poller.getFeatures(context: Context())
         XCTAssertEqual(poller.etag, "W/\"710-wJiNH+MQpj0ruMo7n/9j36tB+Fg\"")
     }
 
@@ -37,7 +37,7 @@ final class PollerTests: XCTestCase {
         poller.etag = "W/\"7c-GUwjw43L+nPpd9TY5PHtsXJueiM\""
 
         XCTAssertEqual(poller.etag, "W/\"7c-GUwjw43L+nPpd9TY5PHtsXJueiM\"")
-        poller.getFeatures(context: [:])
+        poller.getFeatures(context: Context())
         XCTAssertEqual(poller.etag, "W/\"7c-GUwjw43L+nPpd9TY5PHtsXJueiM\"")
     }
 
@@ -46,7 +46,7 @@ final class PollerTests: XCTestCase {
         let session = MockPollerSession(data: nil, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect .data PollerError.")
-        poller.start(context: [:]) { error in
+        poller.start(context: Context()) { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }
@@ -59,7 +59,7 @@ final class PollerTests: XCTestCase {
         let session = MockPollerSession(data: data, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect error to be nil.")
-        poller.start(context: [:]) { error in
+        poller.start(context: Context()) { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }
@@ -73,7 +73,7 @@ final class PollerTests: XCTestCase {
             let session = MockPollerSession(data: data, response: response)
             let poller = createPoller(with: session)
             let expectation = XCTestExpectation(description: "Expect .network PollerError for status: \(statusCode).")
-            poller.start(context: [:]) { error in
+            poller.start(context: Context()) { error in
                 XCTAssertEqual(error, .network)
                 expectation.fulfill()
             }
@@ -88,7 +88,7 @@ final class PollerTests: XCTestCase {
         let session = MockPollerSession(data: data, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect .decoding PollerError.")
-        poller.start(context: [:]) { error in
+        poller.start(context: Context()) { error in
             XCTAssertEqual(error, .decoding)
             expectation.fulfill()
         }
@@ -101,7 +101,7 @@ final class PollerTests: XCTestCase {
         let session = MockPollerSession(data: data, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect error to be nil.")
-        poller.start(context: [:]) { error in
+        poller.start(context: Context()) { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -118,6 +118,7 @@
             var context: [String: String] = [:]
             context["userId"] = "uuid 123-test"
             context["sessionId"] = "uuid-234-test"
+            context["customConextKeyWorksButPreferProperties"] = "someValue";
             var properties: [String: String] = [:]
             properties["customKey"] = "customValue";
             
@@ -125,6 +126,6 @@
             
             let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
 
-            XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid%20123-test") && url.contains("environment=dev") && url.contains("properties%5BcustomKey%5D=customValue"))
+            XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid%20123-test") && url.contains("environment=dev") && url.contains("properties%5BcustomKey%5D=customValue") && url.contains("properties%5BcustomConextKeyWorksButPreferProperties%5D=someValue"))
         }
     }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -118,12 +118,13 @@
             var context: [String: String] = [:]
             context["userId"] = "uuid 123-test"
             context["sessionId"] = "uuid-234-test"
-            unleash.updateContext(context: context)
+            var properties: [String: String] = [:]
+            properties["customKey"] = "customValue";
+            
+            unleash.updateContext(context: context, properties: properties)
             
             let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
 
-
-
-            XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid%20123-test") && url.contains("environment=dev"))
+            XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid%20123-test") && url.contains("environment=dev") && url.contains("properties%5BcustomKey%5D=customValue"))
         }
     }

--- a/UnleashProxyClientSwift.podspec
+++ b/UnleashProxyClientSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 spec.name         = "UnleashProxyClientSwift"
-spec.version      = "0.0.11"
+spec.version      = "0.0.12"
 spec.summary      = "Allows frontend clients to talk to unleash through the unleash proxy"
 spec.homepage     = "https://www.getunleash.io"
 spec.license      = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Adding support for custom/non-standard properties in context (https://docs.getunleash.io/reference/unleash-context#the-properties-field). Also updated documentation explaining how to use it.

Design decisions:
* added second optional param to updateContext. This will allow for a non breaking API change. We could also change a public API to custom Context type but it would require existing users to update their code. Instead I separated standard context fields String map and non-standard custom properties String map in the updateContext method. 

Resolves https://github.com/Unleash/unleash-proxy-client-swift/issues/54

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
Some users may be using custom properties inside the existing context map since Frontend API understands them. Maybe we should copy those to the custom properties map.

Another option is to have a breaking change and introduce a Context type in the public API so that it forces to split known standard properties and user custom properties.

Finally we can avoid changing public SDK API at all and rewrite URL query params behind the scenes to properties[customKey] = customValue. 