### PR TITLE
fix: add unsubscribe method to the client

### DIFF
--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -94,6 +94,10 @@ public class UnleashClientBase {
         }
     }
 
+    public func unsubscribe(name: String) {
+        SwiftEventBus.unsubscribe(self, name: name)
+    }
+
     public func updateContext(context: [String: String], properties: [String:String]? = nil) -> Void {
         let specialKeys: Set = ["appName", "environment", "userId", "sessionId", "remoteAddress"]
         var newProperties: [String: String] = [:]


### PR DESCRIPTION
It was pointed out by @MielchenWafios that we currently have no way of unsubscribing from the subscriptions set up through SwiftEventBus via the unleash client. As a result this makes unsubscribing from events uneccesarily clunky. This PR adds a method to unsubscribe from events.