### PR TITLE
Fix URL encoding of plus (+) sign within query params

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -76,9 +76,13 @@ public class Poller {
 
     func formatURL(context: Context) -> URL? {
         var components = URLComponents(url: unleashUrl, resolvingAgainstBaseURL: false)
-        components?.queryItems = context.toMap().map { key, value in
-            URLQueryItem(name: key, value: value)
-        }
+        components?.percentEncodedQuery = context.toMap().compactMap { key, value in
+            if let encodedKey = key.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved),
+               let encodedValue = value.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved) {
+                return [encodedKey, encodedValue].joined(separator: "=")
+            }
+            return nil
+        }.joined(separator: "&")
 
         return components?.url
     }
@@ -167,4 +171,8 @@ public class Poller {
             completionHandler?(nil)
         })
     }
+}
+
+fileprivate extension CharacterSet {
+    static let rfc3986Unreserved = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
 }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -116,16 +116,23 @@
             let unleash = setupBase(dataGenerator: dataGenerator)
             
             var context: [String: String] = [:]
-            context["userId"] = "uuid 123-test"
+            context["userId"] = "uuid 123+test"
             context["sessionId"] = "uuid-234-test"
-            context["customConextKeyWorksButPreferProperties"] = "someValue";
+            context["customContextKeyWorksButPreferProperties"] = "someValue";
             var properties: [String: String] = [:]
             properties["customKey"] = "customValue";
-            
+            properties["custom+Key"] = "custom+Value";
+
             unleash.updateContext(context: context, properties: properties)
             
             let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
 
-            XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid%20123-test") && url.contains("environment=dev") && url.contains("properties%5BcustomKey%5D=customValue") && url.contains("properties%5BcustomConextKeyWorksButPreferProperties%5D=someValue"))
+            XCTAssert(url.contains("appName=test"), url)
+            XCTAssert(url.contains("sessionId=uuid-234-test"), url)
+            XCTAssert(url.contains("userId=uuid%20123%2Btest"), url)
+            XCTAssert(url.contains("environment=dev"), url)
+            XCTAssert(url.contains("properties%5BcustomKey%5D=customValue"), url)
+            XCTAssert(url.contains("properties%5BcustomContextKeyWorksButPreferProperties%5D=someValue"), url)
+            XCTAssert(url.contains("properties%5Bcustom%2BKey%5D=custom%2BValue"), url)
         }
     }


### PR DESCRIPTION
## About the changes
Adds proper encoding if a context/property contains a plus (`+`) sign. The typical use-case for this is using email aliases such as unleash+1@example.com, feature toggles would fail to evaluate to true if a constraint was added for this `userId`.

I added some test cases to the unit tests and they are passing, but I'm happy to help refactor if there is a better approach to this.