### PR TITLE
Fix Poller context using initial value provided on start, rather than latest from updateContext

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -76,9 +76,13 @@ public class Poller {
 
     func formatURL(context: Context) -> URL? {
         var components = URLComponents(url: unleashUrl, resolvingAgainstBaseURL: false)
-        components?.queryItems = context.toMap().map { key, value in
-            URLQueryItem(name: key, value: value)
-        }
+        components?.percentEncodedQuery = context.toMap().compactMap { key, value in
+            if let encodedKey = key.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved),
+               let encodedValue = value.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved) {
+                return [encodedKey, encodedValue].joined(separator: "=")
+            }
+            return nil
+        }.joined(separator: "&")
 
         return components?.url
     }
@@ -167,4 +171,8 @@ public class Poller {
             completionHandler?(nil)
         })
     }
+}
+
+fileprivate extension CharacterSet {
+    static let rfc3986Unreserved = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
 }

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -97,7 +97,8 @@ public class UnleashClientBase {
         SwiftEventBus.unregister(self, name: name)
     }
 
-    public func updateContext(context: [String: String], properties: [String:String]? = nil) -> Void {
+    /// Set the context without stopping/starting the poller.
+    public func setContext(context: [String: String], properties: [String:String]? = nil) -> Void {
         let specialKeys: Set = ["appName", "environment", "userId", "sessionId", "remoteAddress"]
         var newProperties: [String: String] = [:]
 
@@ -110,7 +111,7 @@ public class UnleashClientBase {
         properties?.forEach { (key, value) in
             newProperties[key] = value
         }
-        
+
         let newContext = Context(
             appName: poller.context.appName,
             environment: poller.context.environment,
@@ -121,6 +122,11 @@ public class UnleashClientBase {
         )
 
         poller.context = newContext
+    }
+
+    /// Update the context and stop/start the poller.
+    public func updateContext(context: [String: String], properties: [String:String]? = nil) -> Void {
+        self.setContext(context: context, properties: properties)
         self.stop()
         self.start()
     }

--- a/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
@@ -47,12 +47,12 @@ public class MockDictionaryStorageProvider: StorageProvider {
 class MockPoller: Poller {
     var dataGenerator: () -> [String: Toggle];
     
-    init(callback: @escaping () -> [String: Toggle], unleashUrl: URL, apiKey: String, session: PollerSession) {
+    init(callback: @escaping () -> [String: Toggle], unleashUrl: URL, apiKey: String, context: Context, session: PollerSession) {
         self.dataGenerator = callback
-        super.init(refreshInterval: 15, unleashUrl: unleashUrl, apiKey: apiKey, session: session)
+        super.init(refreshInterval: 15, unleashUrl: unleashUrl, apiKey: apiKey, context: context, session: session)
     }
     
-    override func getFeatures(context: Context, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
+    override func getFeatures(completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
         self.storageProvider = MockDictionaryStorageProvider(storage: dataGenerator())
     }
 }

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -14,7 +14,7 @@ final class PollerTests: XCTestCase {
         let poller = createPoller(with: session)
 
         XCTAssertTrue(poller.etag.isEmpty)
-        poller.getFeatures(context: Context())
+        poller.getFeatures()
         XCTAssertEqual(poller.etag, "W/\"77f-WboeNIYTrCbEJ+TK78VuhInQn2M\"")
     }
 
@@ -25,7 +25,7 @@ final class PollerTests: XCTestCase {
         let poller = createPoller(with: session)
 
         XCTAssertTrue(poller.etag.isEmpty)
-        poller.getFeatures(context: Context())
+        poller.getFeatures()
         XCTAssertEqual(poller.etag, "W/\"710-wJiNH+MQpj0ruMo7n/9j36tB+Fg\"")
     }
 
@@ -37,7 +37,7 @@ final class PollerTests: XCTestCase {
         poller.etag = "W/\"7c-GUwjw43L+nPpd9TY5PHtsXJueiM\""
 
         XCTAssertEqual(poller.etag, "W/\"7c-GUwjw43L+nPpd9TY5PHtsXJueiM\"")
-        poller.getFeatures(context: Context())
+        poller.getFeatures()
         XCTAssertEqual(poller.etag, "W/\"7c-GUwjw43L+nPpd9TY5PHtsXJueiM\"")
     }
 
@@ -46,7 +46,7 @@ final class PollerTests: XCTestCase {
         let session = MockPollerSession(data: nil, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect .data PollerError.")
-        poller.start(context: Context()) { error in
+        poller.start() { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }
@@ -59,7 +59,7 @@ final class PollerTests: XCTestCase {
         let session = MockPollerSession(data: data, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect error to be nil.")
-        poller.start(context: Context()) { error in
+        poller.start() { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }
@@ -73,7 +73,7 @@ final class PollerTests: XCTestCase {
             let session = MockPollerSession(data: data, response: response)
             let poller = createPoller(with: session)
             let expectation = XCTestExpectation(description: "Expect .network PollerError for status: \(statusCode).")
-            poller.start(context: Context()) { error in
+            poller.start() { error in
                 XCTAssertEqual(error, .network)
                 expectation.fulfill()
             }
@@ -88,7 +88,7 @@ final class PollerTests: XCTestCase {
         let session = MockPollerSession(data: data, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect .decoding PollerError.")
-        poller.start(context: Context()) { error in
+        poller.start() { error in
             XCTAssertEqual(error, .decoding)
             expectation.fulfill()
         }
@@ -101,7 +101,7 @@ final class PollerTests: XCTestCase {
         let session = MockPollerSession(data: data, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect error to be nil.")
-        poller.start(context: Context()) { error in
+        poller.start() { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }
@@ -109,7 +109,7 @@ final class PollerTests: XCTestCase {
     }
 
     private func createPoller(with session: PollerSession, url: URL? = nil) -> Poller {
-        return Poller(refreshInterval: nil, unleashUrl: url ?? unleashUrl, apiKey: apiKey, session: session)
+        return Poller(refreshInterval: nil, unleashUrl: url ?? unleashUrl, apiKey: apiKey, context: Context(), session: session)
     }
 
     private func mockResponse(statusCode: Int = 200, headerFields: [String : String]? = nil) -> URLResponse {

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -116,16 +116,23 @@
             let unleash = setupBase(dataGenerator: dataGenerator)
             
             var context: [String: String] = [:]
-            context["userId"] = "uuid 123-test"
+            context["userId"] = "uuid 123+test"
             context["sessionId"] = "uuid-234-test"
-            context["customConextKeyWorksButPreferProperties"] = "someValue";
+            context["customContextKeyWorksButPreferProperties"] = "someValue";
             var properties: [String: String] = [:]
             properties["customKey"] = "customValue";
-            
+            properties["custom+Key"] = "custom+Value";
+
             unleash.updateContext(context: context, properties: properties)
             
             let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
 
-            XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid%20123-test") && url.contains("environment=dev") && url.contains("properties%5BcustomKey%5D=customValue") && url.contains("properties%5BcustomConextKeyWorksButPreferProperties%5D=someValue"))
+            XCTAssert(url.contains("appName=test"), url)
+            XCTAssert(url.contains("sessionId=uuid-234-test"), url)
+            XCTAssert(url.contains("userId=uuid%20123%2Btest"), url)
+            XCTAssert(url.contains("environment=dev"), url)
+            XCTAssert(url.contains("properties%5BcustomKey%5D=customValue"), url)
+            XCTAssert(url.contains("properties%5BcustomContextKeyWorksButPreferProperties%5D=someValue"), url)
+            XCTAssert(url.contains("properties%5Bcustom%2BKey%5D=custom%2BValue"), url)
         }
     }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -58,9 +58,12 @@
             context["sessionId"] = "uuid-234-test"
             unleash.updateContext(context: context)
             
-            let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
+            let url = unleash.poller.formatURL()!.absoluteString
             
-            XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid-123-test") && url.contains("environment=dev"))
+            XCTAssert(url.contains("appName=test"), url)
+            XCTAssert(url.contains("sessionId=uuid-234-test"), url)
+            XCTAssert(url.contains("userId=uuid-123-test"), url)
+            XCTAssert(url.contains("environment=dev"), url)
         }
     }
 
@@ -125,7 +128,7 @@
 
             unleash.updateContext(context: context, properties: properties)
             
-            let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
+            let url = unleash.poller.formatURL()!.absoluteString
 
             XCTAssert(url.contains("appName=test"), url)
             XCTAssert(url.contains("sessionId=uuid-234-test"), url)

--- a/Tests/UnleashProxyClientSwiftTests/testUtils.swift
+++ b/Tests/UnleashProxyClientSwiftTests/testUtils.swift
@@ -31,9 +31,11 @@ func generateTestToggleMapWithVariant() -> [String: Toggle] {
     return toggleMap
 }
 
+let defaultContext = Context(appName: "test", environment: "dev")
+
 @available(iOS 13, *)
-func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) -> UnleashClient {
-    let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
+func setup(dataGenerator: @escaping () -> [String: Toggle], context: Context = defaultContext, session: PollerSession = MockPollerSession()) -> UnleashClient {
+    let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", context: context, session: session)
     let metrics = MockMetrics(appName: "test")
 
     let unleash = UnleashProxyClientSwift.UnleashClient(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)
@@ -42,8 +44,8 @@ func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSessi
     return unleash
 }
 
-func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) -> UnleashClientBase {
-    let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
+func setupBase(dataGenerator: @escaping () -> [String: Toggle], context: Context = defaultContext, session: PollerSession = MockPollerSession()) -> UnleashClientBase {
+    let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", context: context, session: session)
     let metrics = MockMetrics(appName: "test")
 
     let unleash = UnleashProxyClientSwift.UnleashClientBase(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)


### PR DESCRIPTION
## About the changes
As I was testing changes in https://github.com/Unleash/unleash-proxy-client-swift/pull/67 I found a bug where the `Poller` timer was referencing the initial `Context` values provided at `start`, rather than values updated later using `updateContext`.

I believe the issue was originally the context was passed in as a dictionary, which I believe is passed by reference, to each time the timer would fire it would get the updated values. On creating a `struct Context` it is passed by value, so the timer completion block captures the initial values, and is not updated:

```swift
    public func start(context: Context, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
        self.getFeatures(context: context, completionHandler: completionHandler)

        let timer = Timer.scheduledTimer(withTimeInterval: Double(self.refreshInterval ?? 15), repeats: true) { timer in
            self.getFeatures(context: context)  // <---- uses value of context passed on start
        }
```

 This bug was introduced by this PR: https://github.com/Unleash/unleash-proxy-client-swift/pull/55
