### PR TITLE
Add ability to set Context on UnleashClientBase.init

### DIFF
--- a/Sources/UnleashProxyClientSwift/Context.swift
+++ b/Sources/UnleashProxyClientSwift/Context.swift
@@ -1,12 +1,12 @@
 public struct Context {
-    let appName: String?
-    let environment: String?
-    var userId: String?
-    var sessionId: String?
-    var remoteAddress: String?
-    var properties: [String: String]?
-    
-    init(
+    public let appName: String
+    public let environment: String?
+    public let userId: String?
+    public let sessionId: String?
+    public let remoteAddress: String?
+    public let properties: [String: String]?
+
+    public init(
         appName: String? = nil,
         environment: String? = nil,
         userId: String? = nil,
@@ -14,7 +14,7 @@ public struct Context {
         remoteAddress: String? = nil,
         properties: [String: String]? = nil
     ) {
-        self.appName = appName
+        self.appName = appName ?? "unleash-swift-client"
         self.environment = environment
         self.userId = userId
         self.sessionId = sessionId
@@ -24,20 +24,18 @@ public struct Context {
     
     func toMap() -> [String: String] {
         var params: [String: String] = [:]
+        params["appName"] = appName
+        if let environment = self.environment {
+            params["environment"] = environment
+        }
         if let userId = self.userId {
             params["userId"] = userId
-        }
-        if let remoteAddress = self.remoteAddress {
-            params["remoteAddress"] = remoteAddress
         }
         if let sessionId = self.sessionId {
             params["sessionId"] = sessionId
         }
-        if let appName = self.appName {
-            params["appName"] = appName
-        }
-        if let environment = self.environment {
-            params["environment"] = environment
+        if let remoteAddress = self.remoteAddress {
+            params["remoteAddress"] = remoteAddress
         }
         properties?.forEach { (key, value) in
             params["properties[\(key)]"] = value

--- a/Sources/UnleashProxyClientSwift/Context.swift
+++ b/Sources/UnleashProxyClientSwift/Context.swift
@@ -1,10 +1,10 @@
 public struct Context {
     public let appName: String
     public let environment: String?
-    public let userId: String?
-    public let sessionId: String?
-    public let remoteAddress: String?
-    public let properties: [String: String]?
+    public var userId: String?
+    public var sessionId: String?
+    public var remoteAddress: String?
+    public var properties: [String: String]
 
     public init(
         appName: String? = nil,
@@ -12,7 +12,7 @@ public struct Context {
         userId: String? = nil,
         sessionId: String? = nil,
         remoteAddress: String? = nil,
-        properties: [String: String]? = nil
+        properties: [String: String] = [:]
     ) {
         self.appName = appName ?? "unleash-swift-client"
         self.environment = environment
@@ -37,7 +37,7 @@ public struct Context {
         if let remoteAddress = self.remoteAddress {
             params["remoteAddress"] = remoteAddress
         }
-        properties?.forEach { (key, value) in
+        properties.forEach { (key, value) in
             params["properties[\(key)]"] = value
         }
         return params

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -33,12 +33,38 @@ public class UnleashClientBase {
     var poller: Poller
     var metrics: Metrics
 
-    public init(unleashUrl: String, clientKey: String, refreshInterval: Int = 15, metricsInterval: Int = 30, disableMetrics: Bool = false, appName: String = "unleash-swift-client", environment: String? = nil, poller: Poller? = nil, metrics: Metrics? = nil) {
+    public convenience init(unleashUrl: String,
+                            clientKey: String,
+                            refreshInterval: Int = 15,
+                            metricsInterval: Int = 30,
+                            disableMetrics: Bool = false,
+                            appName: String? = nil,
+                            environment: String? = nil,
+                            poller: Poller? = nil,
+                            metrics: Metrics? = nil) {
+        self.init(unleashUrl: unleashUrl,
+                  clientKey: clientKey,
+                  refreshInterval: refreshInterval,
+                  metricsInterval: metricsInterval,
+                  disableMetrics: disableMetrics,
+                  context: Context(appName: appName, environment: environment),
+                  poller: poller,
+                  metrics: metrics)
+    }
+
+    public init(unleashUrl: String,
+                clientKey: String,
+                refreshInterval: Int = 15,
+                metricsInterval: Int = 30,
+                disableMetrics: Bool = false,
+                context: Context,
+                poller: Poller? = nil,
+                metrics: Metrics? = nil) {
         guard let url = URL(string: unleashUrl), url.scheme != nil else {
             fatalError("Invalid Unleash URL: \(unleashUrl)")
         }
 
-        self.context = Context(appName: appName, environment: environment)
+        self.context = context
 
         self.timer = nil
         if let poller = poller {
@@ -59,7 +85,7 @@ public class UnleashClientBase {
                 }
                 task.resume()
             }
-            self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey)
+            self.metrics = Metrics(appName: context.appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey)
         }
 
     }

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -133,17 +133,17 @@ public class UnleashClientBase {
     public func updateContext(context: [String: String], properties: [String:String]? = nil) -> Void {
         let specialKeys: Set = ["appName", "environment", "userId", "sessionId", "remoteAddress"]
         var newProperties: [String: String] = [:]
-        
+
         context.forEach { (key, value) in
             if !specialKeys.contains(key) {
                 newProperties[key] = value
             }
         }
-        
+
         properties?.forEach { (key, value) in
             newProperties[key] = value
         }
-        
+
         let newContext = Context(
             appName: self.context.appName,
             environment: self.context.environment,
@@ -152,7 +152,7 @@ public class UnleashClientBase {
             remoteAddress: context["remoteAddress"],
             properties: newProperties
         )
-        
+
         self.updateContext(newContext)
     }
 }

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -124,16 +124,22 @@ public class UnleashClientBase {
         SwiftEventBus.unregister(self, name: name)
     }
 
+    public func updateContext(_ newContext: Context) -> Void {
+        self.context = newContext
+        self.stop()
+        self.start()
+    }
+
     public func updateContext(context: [String: String], properties: [String:String]? = nil) -> Void {
         let specialKeys: Set = ["appName", "environment", "userId", "sessionId", "remoteAddress"]
         var newProperties: [String: String] = [:]
-
+        
         context.forEach { (key, value) in
             if !specialKeys.contains(key) {
                 newProperties[key] = value
             }
         }
-
+        
         properties?.forEach { (key, value) in
             newProperties[key] = value
         }
@@ -146,10 +152,8 @@ public class UnleashClientBase {
             remoteAddress: context["remoteAddress"],
             properties: newProperties
         )
-
-        self.context = newContext
-        self.stop()
-        self.start()
+        
+        self.updateContext(newContext)
     }
 }
 


### PR DESCRIPTION
## About the changes
Currently `UnleashClientBase.init` only allows setting `appName` and `environment` context variables. This means for other "static" context variables we currently need to do the following (simplified):

```swift
let init = UnleashClientBase.init(appName: "example-app", environment: "development")

client.start()

// Internally calls an unnecessary stop/start
client.updateContext(context: ["appVersion": "1.2.3"])
```

In my case the static variable is the current `appVersion`, but I'm sure there are other use-cases out there.

With these changes you can do the following instead:

```swift
let context = Context(appName: "example-app", environment: "development", properties: ["appVersion": "1.2.3"])
let init = UnleashClientBase.init(context: context)

client.start()

// Call to updateContext not needed avoiding extra stop/start
```