### PR TITLE
Invalidate timer if Poller.start is called twice without stop

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -63,6 +63,9 @@ public class Poller {
     public func start(context: Context, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
         self.getFeatures(context: context, completionHandler: completionHandler)
 
+        // Invalidate timer if we've already called start
+        self.timer?.invalidate()
+
         let timer = Timer.scheduledTimer(withTimeInterval: Double(self.refreshInterval ?? 15), repeats: true) { timer in
             self.getFeatures(context: context)
         }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -135,4 +135,31 @@
             XCTAssert(url.contains("properties%5BcustomContextKeyWorksButPreferProperties%5D=someValue"), url)
             XCTAssert(url.contains("properties%5Bcustom%2BKey%5D=custom%2BValue"), url)
         }
+
+        func testUpdateContextBeforeStartInvalidatesExistingTimer() {
+            func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
+                return generateTestToggleMapWithVariant()
+            }
+
+            let unleash = setupBase(dataGenerator: dataGenerator, callStart: false)
+
+            var context: [String: String] = [:]
+            context["userId"] = "uuid 123+test"
+            context["sessionId"] = "uuid-234-test"
+            context["customContextKeyWorksButPreferProperties"] = "someValue";
+            var properties: [String: String] = [:]
+            properties["customKey"] = "customValue";
+            properties["custom+Key"] = "custom+Value";
+
+            unleash.updateContext(context: context, properties: properties)
+
+            let timer1 = unleash.poller.timer
+
+            unleash.start()
+
+            let timer2 = unleash.poller.timer
+
+            XCTAssertFalse(timer1!.isValid)
+            XCTAssertTrue(timer2!.isValid)
+        }
     }

--- a/Tests/UnleashProxyClientSwiftTests/testUtils.swift
+++ b/Tests/UnleashProxyClientSwiftTests/testUtils.swift
@@ -42,12 +42,14 @@ func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSessi
     return unleash
 }
 
-func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) -> UnleashClientBase {
+func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession(), callStart: Bool = true) -> UnleashClientBase {
     let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
     let metrics = MockMetrics(appName: "test")
 
     let unleash = UnleashProxyClientSwift.UnleashClientBase(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)
 
-    unleash.start()
+    if callStart {
+        unleash.start()
+    }
     return unleash
 }


### PR DESCRIPTION
## About the changes
Here is my original PR, which incorrectly addressed the issue I was having: https://github.com/Unleash/unleash-proxy-client-swift/pull/68

This is also related to this PR: https://github.com/Unleash/unleash-proxy-client-swift/pull/71

Basically I was doing the following:
```swift
let init = UnleashClientBase.init(appName: "example-app", environment: "development")

client.updateContext(context: ["appVersion": "1.2.3"])

client.start(false) { error in
      ...
  }
```

Internally `updateContext` calls `Poller.stop` then `Poller.start`, *this would start one timer* using the context that has `appVersion` set.

Then the call to `client.start` would *start a second timer* using the original context set that only has `appName` and `environment` set.

So the issue is that I now have two Pollers/timers running with different `Context`s set, which obviously would cause unexpected feature toggle issues.

This PR attempts to fix the issue by calling `self.timer?.invalidate()` before a new `Timer` is created to make sure to cancel any existing timers. It also adds a unit test to make sure this happens.

## Discussion points
- Could call `Poller.stop()` instead of `timer.invalidate` (currently has same affect), I don't have a strong opinion on this
- If other users currently have this issue it might be hard to notice, and fixing this could break things for them if they worked around this unexpected behavior somehow
