### PR TITLE
feat: init context

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In the example above we import the UnleashProxyClientSwift and instantiate the c
 - `clientKey`: either an [client-side API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) if you use the front-end API ([how](https://docs.getunleash.io/how-to/how-to-create-api-tokens 'how do I create API tokens?')) or a [proxy client key](https://docs.getunleash.io/reference/api-tokens-and-client-keys#proxy-client-keys) if you use the proxy [String]
 - `refreshInterval`: the polling interval in seconds [Int]. Set to `0`to only poll once and disable a periodic polling
 - `appName`: the application name identifier [String]
-- `context`: the context paramters except from `appName` and `environment` which should be specified explicitly in the init [String: String]
+- `context`: the context paramters except from `appName` and `environment` which should be specified explicitly in the init [[String: String]]
 
 Running `unleash.start()` will make the first request against the proxy and retrieve the feature toggle configuration, and set up the polling interval in the background.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import UnleashProxyClientSwift
 
 // Setup Unleash in the context where it makes most sense
 
-var unleash = UnleashProxyClientSwift.UnleashClient(unleashUrl: "https://<unleash-instance>/api/frontend", clientKey: "<client-side-api-token>", refreshInterval: 15, appName: "test")
+var unleash = UnleashProxyClientSwift.UnleashClient(unleashUrl: "https://<unleash-instance>/api/frontend", clientKey: "<client-side-api-token>", refreshInterval: 15, appName: "test", context: ["userId": "c3b155b0-5ebe-4a20-8386-e0cab160051e"])
 
 unleash.start()
 ```
@@ -45,7 +45,7 @@ import UnleashProxyClientSwift
 
 // Setup Unleash in the context where it makes most sense
 
-var unleash = UnleashProxyClientSwift.UnleashClientBase(unleashUrl: "https://<unleash-instance>/api/frontend", clientKey: "<client-side-api-token>", refreshInterval: 15, appName: "test")
+var unleash = UnleashProxyClientSwift.UnleashClientBase(unleashUrl: "https://<unleash-instance>/api/frontend", clientKey: "<client-side-api-token>", refreshInterval: 15, appName: "test", context: ["userId": "c3b155b0-5ebe-4a20-8386-e0cab160051e"])
 
 unleash.start()
 ```
@@ -56,6 +56,7 @@ In the example above we import the UnleashProxyClientSwift and instantiate the c
 - `clientKey`: either an [client-side API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) if you use the front-end API ([how](https://docs.getunleash.io/how-to/how-to-create-api-tokens 'how do I create API tokens?')) or a [proxy client key](https://docs.getunleash.io/reference/api-tokens-and-client-keys#proxy-client-keys) if you use the proxy [String]
 - `refreshInterval`: the polling interval in seconds [Int]. Set to `0`to only poll once and disable a periodic polling
 - `appName`: the application name identifier [String]
+- `context`: the context paramters except from `appName` and `environment` which should be specified explicitly in the init [String: String]
 
 Running `unleash.start()` will make the first request against the proxy and retrieve the feature toggle configuration, and set up the polling interval in the background.
 
@@ -104,6 +105,7 @@ var properties: [String: String] = [:]
 properties["customKey"] = "customValue";
 unleash.updateContext(context: context, properties: properties)
 ```
+
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In the example above we import the UnleashProxyClientSwift and instantiate the c
 - `clientKey`: either an [client-side API token](https://docs.getunleash.io/reference/api-tokens-and-client-keys#front-end-tokens) if you use the front-end API ([how](https://docs.getunleash.io/how-to/how-to-create-api-tokens 'how do I create API tokens?')) or a [proxy client key](https://docs.getunleash.io/reference/api-tokens-and-client-keys#proxy-client-keys) if you use the proxy [String]
 - `refreshInterval`: the polling interval in seconds [Int]. Set to `0`to only poll once and disable a periodic polling
 - `appName`: the application name identifier [String]
-- `context`: the context paramters except from `appName` and `environment` which should be specified explicitly in the init [[String: String]]
+- `context`: the context parameters except from `appName` and `environment` which should be specified explicitly in the init [[String: String]]
 
 Running `unleash.start()` will make the first request against the proxy and retrieve the feature toggle configuration, and set up the polling interval in the background.
 

--- a/Sources/UnleashProxyClientSwift/Context.swift
+++ b/Sources/UnleashProxyClientSwift/Context.swift
@@ -1,12 +1,12 @@
 public struct Context {
-    let appName: String?
-    let environment: String?
-    var userId: String?
-    var sessionId: String?
-    var remoteAddress: String?
-    var properties: [String: String]?
+    public let appName: String?
+    public let environment: String?
+    public var userId: String?
+    public var sessionId: String?
+    public var remoteAddress: String?
+    public var properties: [String: String]?
     
-    init(
+    public init(
         appName: String? = nil,
         environment: String? = nil,
         userId: String? = nil,

--- a/Sources/UnleashProxyClientSwift/Context.swift
+++ b/Sources/UnleashProxyClientSwift/Context.swift
@@ -1,12 +1,12 @@
 public struct Context {
-    public let appName: String?
-    public let environment: String?
-    public var userId: String?
-    public var sessionId: String?
-    public var remoteAddress: String?
-    public var properties: [String: String]?
+    let appName: String?
+    let environment: String?
+    var userId: String?
+    var sessionId: String?
+    var remoteAddress: String?
+    var properties: [String: String]?
     
-    public init(
+    init(
         appName: String? = nil,
         environment: String? = nil,
         userId: String? = nil,
@@ -22,7 +22,31 @@ public struct Context {
         self.properties = properties
     }
     
-    func toMap() -> [String: String] {
+    public func toMap() -> [String: String] {
+        var params: [String: String] = [:]
+        properties?.forEach { (key, value) in
+            params[key] = value
+        }
+        if let userId = self.userId {
+            params["userId"] = userId
+        }
+        if let remoteAddress = self.remoteAddress {
+            params["remoteAddress"] = remoteAddress
+        }
+        if let sessionId = self.sessionId {
+            params["sessionId"] = sessionId
+        }
+        if let appName = self.appName {
+            params["appName"] = appName
+        }
+        if let environment = self.environment {
+            params["environment"] = environment
+        }
+        
+        return params
+    }
+    
+    func toURIMap() -> [String: String] {
         var params: [String: String] = [:]
         if let userId = self.userId {
             params["userId"] = userId

--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -76,7 +76,7 @@ public class Poller {
 
     func formatURL(context: Context) -> URL? {
         var components = URLComponents(url: unleashUrl, resolvingAgainstBaseURL: false)
-        components?.percentEncodedQuery = context.toMap().compactMap { key, value in
+        components?.percentEncodedQuery = context.toURIMap().compactMap { key, value in
             if let encodedKey = key.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved),
                let encodedValue = value.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved) {
                 return [encodedKey, encodedValue].joined(separator: "=")

--- a/Tests/UnleashProxyClientSwiftTests/UnleashClientIntegrationTest.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashClientIntegrationTest.swift
@@ -11,7 +11,8 @@ class UnleashIntegrationTests: XCTestCase {
             unleashUrl: "https://sandbox.getunleash.io/enterprise/api/frontend",
             clientKey: "SDKIntegration:development.f0474f4a37e60794ee8fb00a4c112de58befde962af6d5055b383ea3",
             refreshInterval: 15,
-            appName: "testIntegration"
+            appName: "testIntegration",
+            context: ["clientId": "disabled"]
         )
     }
 
@@ -21,40 +22,27 @@ class UnleashIntegrationTests: XCTestCase {
 
     func testUserJourneyHappyPath() {
         let expectation = self.expectation(description: "Waiting for client updates")
-        var updateCount = 0
 
         unleashClient.subscribe(name: "ready", callback: {
-            XCTAssertTrue(self.unleashClient.isEnabled(name: self.featureName), "Feature should be enabled")
+            XCTAssertFalse(self.unleashClient.isEnabled(name: self.featureName), "Feature should be disabled")
 
             let variant = self.unleashClient.getVariant(name: self.featureName)
             XCTAssertNotNil(variant, "Variant should not be nil")
-            XCTAssertTrue(variant.enabled, "Variant should be enabled")
+            XCTAssertFalse(variant.enabled, "Variant should be disabled")
+
+            self.unleashClient.updateContext(context: ["clientId": "enabled"]);
         })
         
         unleashClient.subscribe(name: "update", callback: {
-            updateCount += 1
+            XCTAssertTrue(self.unleashClient.isEnabled(name: self.featureName), "Feature should be enabled")
+            let variant = self.unleashClient.getVariant(name: self.featureName)
+            XCTAssertTrue(variant.enabled, "Variant should be enabled")
+            XCTAssert(variant.name == "feature-variant")
             
-            if updateCount == 1 {
-                XCTAssertFalse(self.unleashClient.isEnabled(name: self.featureName), "Feature should be disabled")
-
-                let variant = self.unleashClient.getVariant(name: self.featureName)
-                XCTAssertNotNil(variant, "Variant should not be nil")
-                XCTAssertFalse(variant.enabled, "Variant should be disabled")
-
-                self.unleashClient.updateContext(context: ["clientId": "enabled"]);
-            } else if updateCount == 2 {
-                XCTAssertTrue(self.unleashClient.isEnabled(name: self.featureName), "Feature should be enabled")
-                let variant = self.unleashClient.getVariant(name: self.featureName)
-                XCTAssertTrue(variant.enabled, "Variant should be enabled")
-                XCTAssert(variant.name == "feature-variant")
-                
-                expectation.fulfill()
-            }
+            expectation.fulfill()
         });
 
         unleashClient.start()
-
-        self.unleashClient.updateContext(context: ["clientId": "disabled"]);
 
         wait(for: [expectation], timeout: 5)
     }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashClientIntegrationTest.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashClientIntegrationTest.swift
@@ -22,6 +22,8 @@ class UnleashIntegrationTests: XCTestCase {
 
     func testUserJourneyHappyPath() {
         let expectation = self.expectation(description: "Waiting for client updates")
+        
+        XCTAssertEqual(unleashClient.context.toMap(), ["environment": "default", "clientId": "disabled", "appName": "testIntegration"])
 
         unleashClient.subscribe(name: "ready", callback: {
             XCTAssertFalse(self.unleashClient.isEnabled(name: self.featureName), "Feature should be disabled")


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Ability to pass initial context fields when initializing the client

Design considerations:
* event though having a strongly typed context would be a nicer solution overall it's a bigger change that I'd like to handle together with the updateContext refactoring to have a symmetrical API. We can try this breaking change in version 2.0 of this client. For now I'd like to avoid increasing the API surface area and adding 2 types of init/updateContext
* since updateContext accepts [String: String] I am thinking about exposing the same Stringly typed context into the init method
* I extracted calculateContext method that will apply to both updateContext and init to split flat context [String, String] into standard context fields and user defined properties. But from the usage perspective it's just one Stringly typed map
* appName and environments are always taken from the explicit fields (for backwards compatibility) and everything else can be overwritten with context

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
