### PR TITLE
Allow attaching completion handler for updating context.

### DIFF
--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -101,10 +101,9 @@ public class UnleashClientBase {
         SwiftEventBus.unregister(self, name: name)
     }
     
-    public func updateContext(context: [String: String], properties: [String:String]? = nil) -> Void {
+    public func updateContext(context: [String: String], properties: [String:String]? = nil, completionHandler: ((PollerError?) -> Void)? = nil) {
         self.context = self.calculateContext(context: context, properties: properties)
-        self.stop()
-        self.start()
+        self.start(completionHandler: completionHandler)
     }
 
     func calculateContext(context: [String: String], properties: [String:String]? = nil) -> Context {


### PR DESCRIPTION
## About the changes

This PR adds optional completion handler to `updateContext` method. This is needed to receive a callback once update is complete.

My use-case:

I need to receive updated configuration after user logs in (several user profile fields are set in context). Those fields can determine A/B test variants and feature flags user can receive. To achieve this, I call updateContext(completion:) before letting user in the app after logging in.

## Discussion points

This addition is non-breaking, as parameter has default value of nil.

I also removed `stop` method call in this function, as `stop` method is already called in `start` function. However, this change is optional, I can put it back if maintainers think it's good for consistency.
