### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/UnleashProxyClientSwift.podspec
+++ b/UnleashProxyClientSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 spec.name         = "UnleashProxyClientSwift"
-spec.version      = "1.1.1"
+spec.version      = "1.2.0"
 spec.summary      = "Allows frontend clients to talk to unleash through the unleash edge, frontend API or the (deprecated) unleash proxy"
 spec.homepage     = "https://www.getunleash.io"
 spec.license      = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
Bumps the version to 1.2.0 for the cocoa pods release