### PR TITLE
Custom Client Headers

### DIFF
--- a/Sources/UnleashProxyClientSwift/Metrics.swift
+++ b/Sources/UnleashProxyClientSwift/Metrics.swift
@@ -72,6 +72,7 @@ public class Metrics {
     var timer: Timer?
     var bucket: Bucket
     let url: URL
+    let customClientHeaders: [String: String]
 
     init(appName: String,
          metricsInterval: TimeInterval,
@@ -79,7 +80,8 @@ public class Metrics {
          disableMetrics: Bool = false,
          poster: @escaping PosterHandler,
          url: URL,
-         clientKey: String) {
+         clientKey: String,
+         customClientHeaders: [String: String] = [:]) {
         self.appName = appName
         self.metricsInterval = metricsInterval
         self.clock = clock
@@ -88,6 +90,7 @@ public class Metrics {
         self.url = url
         self.clientKey = clientKey
         self.bucket = Bucket(clock: clock)
+        self.customClientHeaders = customClientHeaders
     }
 
     func start() {
@@ -162,6 +165,11 @@ public class Metrics {
         request.addValue("no-cache", forHTTPHeaderField: "Cache")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue(clientKey, forHTTPHeaderField: "Authorization")
+        if !self.customClientHeaders.isEmpty {
+            for (key, value) in self.customClientHeaders {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
+        }
         return request
     }
 }

--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -55,8 +55,9 @@ public class Poller {
     
     private let session: PollerSession
     var storageProvider: StorageProvider
+    let customClientHeaders: [String: String]
 
-    public init(refreshInterval: Int? = nil, unleashUrl: URL, apiKey: String, session: PollerSession = URLSession.shared, storageProvider: StorageProvider = DictionaryStorageProvider()) {
+    public init(refreshInterval: Int? = nil, unleashUrl: URL, apiKey: String, session: PollerSession = URLSession.shared, storageProvider: StorageProvider = DictionaryStorageProvider(), customClientHeaders: [String: String] = [:]) {
         self.refreshInterval = refreshInterval
         self.unleashUrl = unleashUrl
         self.apiKey = apiKey
@@ -65,6 +66,7 @@ public class Poller {
         self.etag = ""
         self.session = session
         self.storageProvider = storageProvider
+        self.customClientHeaders = customClientHeaders
     }
 
     public func start(context: Context, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
@@ -117,6 +119,11 @@ public class Poller {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(self.apiKey, forHTTPHeaderField: "Authorization")
         request.setValue(self.etag, forHTTPHeaderField: "If-None-Match")
+        if !self.customClientHeaders.isEmpty {
+            for (key, value) in self.customClientHeaders {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
+        }
         request.cachePolicy = .reloadIgnoringLocalCacheData
         
         session.perform(request, completionHandler: { (data, response, error) in

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -33,7 +33,7 @@ public class UnleashClientBase {
     var poller: Poller
     var metrics: Metrics
 
-    public init(unleashUrl: String, clientKey: String, refreshInterval: Int = 15, metricsInterval: Int = 30, disableMetrics: Bool = false, appName: String = "unleash-swift-client", environment: String? = "default", context: [String: String]? = nil, poller: Poller? = nil, metrics: Metrics? = nil) {
+    public init(unleashUrl: String, clientKey: String, refreshInterval: Int = 15, metricsInterval: Int = 30, disableMetrics: Bool = false, appName: String = "unleash-swift-client", environment: String? = "default", context: [String: String]? = nil, poller: Poller? = nil, metrics: Metrics? = nil, customClientHeaders: [String: String] = [:]) {
         guard let url = URL(string: unleashUrl), url.scheme != nil else {
             fatalError("Invalid Unleash URL: \(unleashUrl)")
         }
@@ -42,7 +42,7 @@ public class UnleashClientBase {
         if let poller = poller {
             self.poller = poller
         } else {
-            self.poller = Poller(refreshInterval: refreshInterval, unleashUrl: url, apiKey: clientKey)
+            self.poller = Poller(refreshInterval: refreshInterval, unleashUrl: url, apiKey: clientKey, customClientHeaders: customClientHeaders)
         }
         if let metrics = metrics {
             self.metrics = metrics
@@ -57,7 +57,7 @@ public class UnleashClientBase {
                 }
                 task.resume()
             }
-            self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey)
+            self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey, customClientHeaders: customClientHeaders)
         }
         
         self.context = Context(appName: appName, environment: environment)


### PR DESCRIPTION
With these changes, the frontend clients will have the possibility of establishing the connection via another API that requires an authentication header.

For example, if an organization for some reason does not want a direct connection to be established from frontend to unleash, they can have an API that serves as a link between the frontend and unleash but if that API requires an authentication header with this version it would be possible to send it .

My connection is established as follows:
APP -> MyAPI (that require an api key to authenticate) -> unleash-edge -> MyAPI (that require an api key to authenticate) -> Unleash API

Unleash Edge already allows me to do that by passing the key CUSTOM_CLIENT_HEADERS in the environment variables.
