### PR TITLE
fix/on-updateContext maintain print to console state

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -176,7 +176,7 @@ public class Poller {
             
             self.createFeatureMap(features: json)
             if (self.ready) {
-                Printer.printMessage("Flag updated")
+                Printer.printMessage("Flags updated")
                 SwiftEventBus.post("update")
             } else {
                 Printer.printMessage("Initial flags fetched")

--- a/Sources/UnleashProxyClientSwift/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller.swift
@@ -176,8 +176,10 @@ public class Poller {
             
             self.createFeatureMap(features: json)
             if (self.ready) {
+                Printer.printMessage("Flag updated")
                 SwiftEventBus.post("update")
             } else {
+                Printer.printMessage("Initial flags fetched")
                 SwiftEventBus.post("ready")
                 self.ready = true
             }

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -103,7 +103,7 @@ public class UnleashClientBase {
     
     public func updateContext(context: [String: String], properties: [String:String]? = nil, completionHandler: ((PollerError?) -> Void)? = nil) {
         self.context = self.calculateContext(context: context, properties: properties)
-        self.start(completionHandler: completionHandler)
+        self.start(Printer.showPrintStatements, completionHandler: completionHandler)
     }
 
     func calculateContext(context: [String: String], properties: [String:String]? = nil) -> Context {

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -66,7 +66,11 @@
                 return generateTestToggleMapWithVariant()
             }
             
-            let unleash = setup(dataGenerator: dataGenerator)
+            let stubPrintToConsoleAtStart = true
+            let unleash = setup(
+                dataGenerator: dataGenerator,
+                printToConsole: stubPrintToConsoleAtStart
+            )
             
             var context: [String: String] = [:]
             context["userId"] = "uuid-123-test"
@@ -76,6 +80,7 @@
             let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
             
             XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid-123-test") && url.contains("environment=dev"))
+            XCTAssertEqual(Printer.showPrintStatements, stubPrintToConsoleAtStart)
         }
         
         @MainActor

--- a/Tests/UnleashProxyClientSwiftTests/testUtils.swift
+++ b/Tests/UnleashProxyClientSwiftTests/testUtils.swift
@@ -32,44 +32,43 @@ func generateTestToggleMapWithVariant() -> [String: Toggle] {
 }
 
 @available(iOS 13, *)
-func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) -> UnleashClient {
+func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession(), printToConsole: Bool = false) -> UnleashClient {
     let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
     let metrics = MockMetrics(appName: "test")
 
     let unleash = UnleashProxyClientSwift.UnleashClient(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)
 
-    unleash.start()
+    unleash.start(printToConsole)
     return unleash
 }
 
 @available(iOS 13, *)
-func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) async throws -> UnleashClient {
+func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession(), printToConsole: Bool = false) async throws -> UnleashClient {
     let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
     let metrics = MockMetrics(appName: "test")
 
     let unleash = UnleashProxyClientSwift.UnleashClient(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)
 
-    try await unleash.start()
+    try await unleash.start(printToConsole)
     return unleash
 }
 
-func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) -> UnleashClientBase {
+func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession(), printToConsole: Bool = false) -> UnleashClientBase {
     let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
     let metrics = MockMetrics(appName: "test")
 
     let unleash = UnleashProxyClientSwift.UnleashClientBase(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)
 
-    unleash.start()
+    unleash.start(printToConsole)
     return unleash
 }
 
-@available(iOS 13, *)
-func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) async throws -> UnleashClientBase {
+func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession(), printToConsole: Bool = false) async throws -> UnleashClientBase {
     let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
     let metrics = MockMetrics(appName: "test")
 
     let unleash = UnleashProxyClientSwift.UnleashClientBase(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)
 
-    try await unleash.start()
+    unleash.start(printToConsole)
     return unleash
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
Relates to issue #88 and findings in [comment](https://github.com/Unleash/unleash-proxy-client-swift/issues/88#issuecomment-2393558284), but does not fix issue in its entirety, just makes clearer what is going on.

It was found that if you call `start(_ printToConsole:Bool)` with `printToConsole` set to true, when you later call updateContext it internally calls `start(false)` which will stop logging and make it appear that polling has stopped as no more statements added.

I've updated this so that when updateContext calls start, it passes along the current value set to the Printer object.

Additionally I've added a few more logs for when flags initially fetched or updated as can appear it is never updating with last log being "No changes..."

<!-- Does it close an issue? Multiple? -->


<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
