### PR TITLE
Feat/async start and updateContext overloads

### DIFF
--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -72,21 +72,7 @@ public class UnleashClientBase {
         poller.start(context: context, completionHandler: completionHandler)
         metrics.start()
     }
-    
-    @available(iOS 13.0, *)
-    @MainActor
-    public func start(_ printToConsole: Bool = false) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
-            start(printToConsole) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
-                }
-            }
-        }
-    }
-    
+
     public func stop() -> Void {
         poller.stop()
         metrics.stop()
@@ -119,20 +105,6 @@ public class UnleashClientBase {
         self.context = self.calculateContext(context: context, properties: properties)
         self.start(completionHandler: completionHandler)
     }
-    
-    @available(iOS 13.0, *)
-    @MainActor
-    public func updateContext(context: [String: String], properties: [String:String]? = nil) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
-            updateContext(context: context, properties: properties) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
-                }
-            }
-        }
-    }
 
     func calculateContext(context: [String: String], properties: [String:String]? = nil) -> Context {
         let specialKeys: Set = ["appName", "environment", "userId", "sessionId", "remoteAddress"]
@@ -163,4 +135,29 @@ public class UnleashClientBase {
 
 @available(iOS 13, tvOS 13, *)
 public class UnleashClient: UnleashClientBase, ObservableObject {
+    @MainActor
+    public func start(_ printToConsole: Bool = false) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            start(printToConsole) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+    
+    @MainActor
+    public func updateContext(context: [String: String], properties: [String:String]? = nil) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            updateContext(context: context, properties: properties) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
 }

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -118,6 +118,19 @@ public class UnleashClientBase {
     public func updateContext(context: [String: String], properties: [String:String]? = nil, completionHandler: ((PollerError?) -> Void)? = nil) {
         self.context = self.calculateContext(context: context, properties: properties)
         self.start(completionHandler: completionHandler)
+    
+    @available(iOS 13.0, *)
+    @MainActor
+    public func updateContext(context: [String: String], properties: [String:String]? = nil) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            updateContext(context: context, properties: properties) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
     }
 
     func calculateContext(context: [String: String], properties: [String:String]? = nil) -> Context {

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -72,7 +72,21 @@ public class UnleashClientBase {
         poller.start(context: context, completionHandler: completionHandler)
         metrics.start()
     }
-
+    
+    @available(iOS 13.0, *)
+    @MainActor
+    public func start(_ printToConsole: Bool = false) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            start(printToConsole) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+    
     public func stop() -> Void {
         poller.stop()
         metrics.stop()

--- a/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/UnleashProxyClientSwift.swift
@@ -118,6 +118,7 @@ public class UnleashClientBase {
     public func updateContext(context: [String: String], properties: [String:String]? = nil, completionHandler: ((PollerError?) -> Void)? = nil) {
         self.context = self.calculateContext(context: context, properties: properties)
         self.start(completionHandler: completionHandler)
+    }
     
     @available(iOS 13.0, *)
     @MainActor

--- a/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
@@ -49,6 +49,7 @@ public class MockDictionaryStorageProvider: StorageProvider {
 
 class MockPoller: Poller {
     var dataGenerator: () -> [String: Toggle];
+    var stubCompletionError: PollerError?
     
     init(callback: @escaping () -> [String: Toggle], unleashUrl: URL, apiKey: String, session: PollerSession) {
         self.dataGenerator = callback
@@ -57,5 +58,6 @@ class MockPoller: Poller {
     
     override func getFeatures(context: Context, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
         self.storageProvider = MockDictionaryStorageProvider(storage: dataGenerator())
+        completionHandler?(stubCompletionError)
     }
 }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -46,6 +46,21 @@
             XCTAssert(unleash.poller.timer != nil)
         }
         
+        @MainActor
+        func testTimerWithAsyncStart() async throws {
+            func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
+                return generateTestToggleMapWithVariant()
+            }
+            
+            let mockedPoller = MockPollerSession()
+            let unleash = try await setup(
+                dataGenerator: dataGenerator,
+                session: mockedPoller
+            )
+            
+            XCTAssert(unleash.poller.timer != nil)
+        }
+        
         func testUpdateContext() {
             func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
                 return generateTestToggleMapWithVariant()
@@ -57,6 +72,24 @@
             context["userId"] = "uuid-123-test"
             context["sessionId"] = "uuid-234-test"
             unleash.updateContext(context: context)
+            
+            let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
+            
+            XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid-123-test") && url.contains("environment=dev"))
+        }
+        
+        @MainActor
+        func testUpdateContextAsync() async throws {
+            func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
+                return generateTestToggleMapWithVariant()
+            }
+            
+            let unleash = try await setup(dataGenerator: dataGenerator)
+            
+            var context: [String: String] = [:]
+            context["userId"] = "uuid-123-test"
+            context["sessionId"] = "uuid-234-test"
+            try await unleash.updateContext(context: context)
             
             let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
             

--- a/Tests/UnleashProxyClientSwiftTests/testUtils.swift
+++ b/Tests/UnleashProxyClientSwiftTests/testUtils.swift
@@ -42,6 +42,17 @@ func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSessi
     return unleash
 }
 
+@available(iOS 13, *)
+func setup(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) async throws -> UnleashClient {
+    let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
+    let metrics = MockMetrics(appName: "test")
+
+    let unleash = UnleashProxyClientSwift.UnleashClient(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)
+
+    try await unleash.start()
+    return unleash
+}
+
 func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) -> UnleashClientBase {
     let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
     let metrics = MockMetrics(appName: "test")
@@ -49,5 +60,16 @@ func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerS
     let unleash = UnleashProxyClientSwift.UnleashClientBase(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)
 
     unleash.start()
+    return unleash
+}
+
+@available(iOS 13, *)
+func setupBase(dataGenerator: @escaping () -> [String: Toggle], session: PollerSession = MockPollerSession()) async throws -> UnleashClientBase {
+    let poller = MockPoller(callback: dataGenerator, unleashUrl: URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!, apiKey: "SECRET", session: session)
+    let metrics = MockMetrics(appName: "test")
+
+    let unleash = UnleashProxyClientSwift.UnleashClientBase(unleashUrl: "https://app.unleash-hosted.com/hosted/api/proxy", clientKey: "dss22d", refreshInterval: 15, appName: "test", environment: "dev", poller: poller, metrics: metrics)
+
+    try await unleash.start()
     return unleash
 }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
This adds async overloads for the start and updateContext methods so that they can safely be called from async context in modern swift concurrency. MainActor requirement is needed for the timer within the Poller to fire on the RunLoop.

<!-- Does it close an issue? Multiple? -->
Fairly sure this should close #88 
Closes #88 

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
