### PR TITLE
fix: self-detect thread

### DIFF
--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -97,8 +97,16 @@ public class UnleashClientBase {
     }
 
     public func subscribe(name: String, callback: @escaping () -> Void) {
-        SwiftEventBus.onBackgroundThread(self, name: name) { result in
-            callback()
+        if Thread.isMainThread {
+            print("Subscribing to \(name) on main thread")
+            SwiftEventBus.onMainThread(self, name: name) { result in
+                callback()
+            }
+        } else {
+            print("Subscribing to \(name) on background thread")
+            SwiftEventBus.onBackgroundThread(self, name: name) { result in
+                callback()
+            }
         }
     }
     


### PR DESCRIPTION
Fixes a bug where `@MainActor` would cause Unleash to crash because SwiftEventBus posts updates on a background thread. This PR fixes the issue by self-detecting if you are on the main thread and subscribing you to the correct thread.

Fixes #98