### PR TITLE
Fix/polling interval zero

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/Poller.swift
@@ -44,16 +44,17 @@ public class Poller {
         context: Context,
         completionHandler: ((PollerError?) -> Void)? = nil
     ) -> Void {
-        if self.refreshInterval == 0 {
-            return
-        }
-
+  
         if toggles.isEmpty {
             self.getFeatures(context: context, completionHandler: completionHandler)
         } else {
             Printer.printMessage("Starting with provided bootstrap toggles")
             createFeatureMap(toggles: toggles)
             completionHandler?(nil)
+        }
+
+        if self.refreshInterval == 0 {
+            return
         }
 
         let timer = Timer.scheduledTimer(withTimeInterval: Double(self.refreshInterval ?? 15), repeats: true) { timer in

--- a/Sources/UnleashProxyClientSwift/Poller/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/Poller.swift
@@ -44,6 +44,10 @@ public class Poller {
         context: Context,
         completionHandler: ((PollerError?) -> Void)? = nil
     ) -> Void {
+        if self.refreshInterval == 0 {
+            return
+        }
+
         if toggles.isEmpty {
             self.getFeatures(context: context, completionHandler: completionHandler)
         } else {

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -230,6 +230,17 @@ final class PollerTests: XCTestCase {
         XCTAssertEqual(poller.getFeature(name: "Bar"), stubToggles.last!)
     }
 
+    func testTimerNotInitializedWhenRefreshIntervalIsZero() {
+        let poller = Poller(
+            refreshInterval: 0,
+            unleashUrl: unleashUrl,
+            apiKey: apiKey,
+            session: MockPollerSession()
+        )
+        
+        XCTAssertNil(poller.timer, "Timer should not be initialized when refreshInterval is zero")
+    }
+
     private func createPoller(
         with session: PollerSession,
         url: URL? = nil,


### PR DESCRIPTION
This PR brings this SDK in line with how other client SDKs works by not initialising the timer when refreshInterval is set to 0.

Fixes #101 