### PR TITLE
feat: Improve the performance of saving toggles to the StorageProvider

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller/DictionaryStorageProvider.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/DictionaryStorageProvider.swift
@@ -12,6 +12,12 @@ public class DictionaryStorageProvider: StorageProvider {
         }
     }
 
+    public func reset(keyedValues: [String : Toggle]) {
+        queue.sync {
+            self.storage = keyedValues
+        }
+    }
+
     public func value(key: String) -> Toggle? {
         queue.sync {
             return self.storage[key]

--- a/Sources/UnleashProxyClientSwift/Poller/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/Poller.swift
@@ -94,7 +94,10 @@ public class Poller {
     
     private func createFeatureMap(toggles: [Toggle]) {
         storageProvider.clear()
-        toggles.forEach { storageProvider.set(value: $0, key: $0.name) }
+        let keyedValues = Dictionary(
+            uniqueKeysWithValues: toggles.map { ($0.name, $0) }
+        )
+        storageProvider.reset(keyedValues: keyedValues)
     }
     
     public func getFeature(name: String) -> Toggle? {

--- a/Sources/UnleashProxyClientSwift/Poller/StorageProvider.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/StorageProvider.swift
@@ -1,5 +1,6 @@
 public protocol StorageProvider {
     func set(value: Toggle?, key: String)
+    func reset(keyedValues: [String: Toggle])
     func value(key: String) -> Toggle?
     func clear()
 }

--- a/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
@@ -38,6 +38,10 @@ public class MockDictionaryStorageProvider: StorageProvider {
         storage[key] = value
     }
 
+    public func reset(keyedValues: [String : Toggle]) {
+        storage = keyedValues
+    }
+
     public func value(key: String) -> Toggle? {
         return storage[key]
     }


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

Currently, the Poller saves toggles to the StorageProvider individually through iteration, which consumes excessive resources. I Added `reset(keyedValues: [String : Toggle])` to StorageProvider interface. This improvement will optimize the process by implementing batch saving of the toggle array to Storage.


<!-- Does it close an issue? Multiple? -->
Closes #112 

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
In the current structure, when creating a StorageProvider that supports disk caching, read/write costs occur as many times as the number of toggles. This is because the toggle array is being iterated through and saved to Storage one by one. This PR is submitted to address this issue.
