### PR TITLE
fix: Use custom poller connectionId

### DIFF
--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -29,11 +29,12 @@ public class UnleashClientBase {
             fatalError("Invalid Unleash URL: \(unleashUrl)")
         }
 
-        self.connectionId = UUID()
         self.timer = nil
         if let poller = poller {
             self.poller = poller
+            self.connectionId = poller.connectionId
         } else {
+            self.connectionId = UUID()
             self.poller = Poller(
                 refreshInterval: refreshInterval,
                 unleashUrl: url,

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -221,4 +221,13 @@ final class unleash_proxy_client_base_swiftTests: XCTestCase {
         XCTAssert(url.contains("properties%5BcustomContextKeyWorksButPreferProperties%5D=someValue"), url)
         XCTAssert(url.contains("properties%5Bcustom%2BKey%5D=custom%2BValue"), url)
     }
+
+    func testConnectionId() {
+        func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
+            return generateTestToggleMapWithVariant()
+        }
+
+        let unleash = setupBase(dataGenerator: dataGenerator)
+        XCTAssertEqual(unleash.connectionId, unleash.poller.connectionId)
+    }
 }


### PR DESCRIPTION
## About the changes
When a custom poller is provided, use its `connectionId` to set the `connectionId` in `UnleashClientBase`, instead of generating one.
`UnleashClientBase.connectionId` is used when reporting metrics. In existing implementation, when a custom poller is provided to `UnleashClientBase.init`, the poller and the client IDs mismatch.