### PR TITLE
WIP: Feat/impression events

### DIFF
--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -92,6 +92,7 @@ public class UnleashClientBase {
     public func isEnabled(name: String) -> Bool {
         let toggle = poller.getFeature(name: name)
         let enabled = toggle?.enabled ?? false
+        
         metrics.count(name: name, enabled: enabled)
         
         if let toggle = toggle, toggle.impressionData {
@@ -110,12 +111,10 @@ public class UnleashClientBase {
         let variant = toggle?.variant ?? .defaultDisabled
         let enabled = toggle?.enabled ?? false
 
-        
         metrics.count(name: name, enabled: enabled)
         metrics.countVariant(name: name, variant: variant.name)
         
-        if let toggle = toggle, toggle.impressionData {
-            
+        if let toggle = toggle, toggle.impressionData {   
             SwiftEventBus.post("impression", sender: ImpressionEvent(
                 toggleName: name,
                 enabled: enabled,

--- a/Sources/UnleashProxyClientSwift/DTO/Toggle.swift
+++ b/Sources/UnleashProxyClientSwift/DTO/Toggle.swift
@@ -16,4 +16,19 @@ public struct Toggle: Codable, Equatable {
         self.impressionData = impressionData
         self.variant = variant
     }
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case enabled
+        case impressionData
+        case variant
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        enabled = try container.decode(Bool.self, forKey: .enabled)
+        variant = try container.decodeIfPresent(Variant.self, forKey: .variant)
+        impressionData = (try? container.decodeIfPresent(Bool.self, forKey: .impressionData)) ?? false
+    }
 }

--- a/Sources/UnleashProxyClientSwift/DTO/Toggle.swift
+++ b/Sources/UnleashProxyClientSwift/DTO/Toggle.swift
@@ -2,15 +2,18 @@
 public struct Toggle: Codable, Equatable {
     public let name: String
     public let enabled: Bool
+    public let impressionData: Bool
     public let variant: Variant?
     
     public init(
         name: String,
         enabled: Bool,
+        impressionData: Bool = false,
         variant: Variant? = nil
     ) {
         self.name = name
         self.enabled = enabled
+        self.impressionData = impressionData
         self.variant = variant
     }
 }

--- a/Sources/UnleashProxyClientSwift/DTO/UnleashEvent.swift
+++ b/Sources/UnleashProxyClientSwift/DTO/UnleashEvent.swift
@@ -8,4 +8,6 @@ public enum UnleashEvent: String, CaseIterable {
     case sent
     /// Emitted when metrics failed to send
     case error
+    /// Emitted when a toggle with impression data is evaluated
+    case impression
 }

--- a/Sources/UnleashProxyClientSwift/Events/ImpressionEvent.swift
+++ b/Sources/UnleashProxyClientSwift/Events/ImpressionEvent.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct ImpressionEvent {
+    public let toggleName: String
+    public let enabled: Bool
+    public let variant: Variant?
+    public let context: Context
+    
+    public init(toggleName: String, enabled: Bool, variant: Variant? = nil, context: Context) {
+        self.toggleName = toggleName
+        self.enabled = enabled
+        self.variant = variant
+        self.context = context
+    }
+} 

--- a/Tests/UnleashProxyClientSwiftTests/ImpressionEventsTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/ImpressionEventsTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+import SwiftEventBus
+@testable import UnleashProxyClientSwift
+
+class ImpressionEventsTests: XCTestCase {
+    struct TestData {
+        static let toggleWithImpressionData = Toggle(
+            name: "test-toggle-impression",
+            enabled: true,
+            impressionData: true,
+            variant: nil
+        )
+        
+        static let toggleWithoutImpressionData = Toggle(
+            name: "test-toggle-no-impression",
+            enabled: true,
+            impressionData: false,
+            variant: nil
+        )
+        
+        static let toggleWithVariant = Toggle(
+            name: "test-toggle-variant",
+            enabled: true,
+            impressionData: true,
+            variant: Variant(name: "test-variant", enabled: true)
+        )
+    }
+    
+    func setup(toggles: [Toggle] = []) -> UnleashClient {
+        let client = UnleashClient(
+            unleashUrl: "https://test-setup.com",
+            clientKey: "test-setup-key",
+            context: ["appName": "test-app", "environment": "test", "userId": "test-user"]
+        )
+        client.start(bootstrap: .toggles(toggles))
+        return client
+    }
+    
+    func testImpressionEventEmittedWhenImpressionDataEnabled() {
+        let toggle = TestData.toggleWithImpressionData
+        let client = setup(toggles: [toggle])
+        let expectation = XCTestExpectation(description: "Impression event received for enabled test")
+        
+        client.subscribe(.impression) { object in
+            guard let impressionEvent = object as? ImpressionEvent else {
+                XCTFail("Expected ImpressionEvent")
+                return
+            }
+    
+            XCTAssertEqual(impressionEvent.toggleName, toggle.name)
+            XCTAssertEqual(impressionEvent.enabled, toggle.enabled)
+
+            XCTAssertNil(impressionEvent.variant)
+            expectation.fulfill()
+        }
+        
+        _ = client.isEnabled(name: toggle.name)
+        wait(for: [expectation], timeout: 1.0)
+        client.stop();
+    }
+    
+    func testNoImpressionEventWhenImpressionDataDisabled() {
+        let toggle = TestData.toggleWithoutImpressionData
+        let client = setup(toggles: [toggle])
+        
+        let expectation = XCTestExpectation(description: "No impression event expected")
+        expectation.isInverted = true
+        client.subscribe(.impression) { _ in expectation.fulfill() }
+        _ = client.isEnabled(name: toggle.name)
+        wait(for: [expectation], timeout: 0.1)
+        client.stop();
+    }
+    
+    func testImpressionEventWithVariantData() {
+        let toggle = TestData.toggleWithVariant
+        let client = setup(toggles: [toggle])
+        let expectation = XCTestExpectation(description: "Impression event received for variant test")
+        
+
+        client.subscribe(.impression) { object in
+            guard let impressionEvent = object as? ImpressionEvent else {
+                XCTFail("Expected ImpressionEvent, got \(String(describing: object))")
+                return
+            }
+            
+            print("impressionEventVariant: \(impressionEvent)")
+            print("impressionEvent.toggleName: \(impressionEvent.toggleName)")
+            print("testData.toggleName: \(TestData.toggleWithVariant.name)")
+            XCTAssertEqual(impressionEvent.toggleName, TestData.toggleWithVariant.name)
+            XCTAssertEqual(impressionEvent.enabled, toggle.enabled)
+            XCTAssertNotNil(impressionEvent.variant)
+            XCTAssertEqual(impressionEvent.variant?.name, toggle.variant?.name)
+            expectation.fulfill()
+        }
+        
+        _ = client.getVariant(name: toggle.name)
+        wait(for: [expectation], timeout: 1.0)
+        client.stop();
+    }
+    
+    func testNoImpressionEventWhenToggleNotFound() {
+        let nonExistentToggle = "non-existent-toggle"
+        let client = setup(toggles: [])
+    
+        let expectation = XCTestExpectation(description: "No impression event expected")
+        expectation.isInverted = true
+        client.subscribe(.impression) { _ in expectation.fulfill() }
+        _ = client.isEnabled(name: nonExistentToggle)
+        wait(for: [expectation], timeout: 0.1)
+        client.stop();
+    }
+} 

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -179,7 +179,7 @@ final class unleash_proxy_client_base_swiftTests: XCTestCase {
         XCTAssert(variantA.name == "TestA" && variantA.enabled == true)
         XCTAssert(variantB.name == "TestB" && variantB.enabled == false)
         XCTAssert(variantC.name == "disabled") // change this to empty variant - name: disabled - enabled: false - empty payload
-        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])];
+        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 0, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])];
         XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics);
         
     }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -32,7 +32,7 @@ final class unleash_proxy_client_swiftTests: XCTestCase {
         XCTAssert(variantA.name == "TestA" && variantA.enabled == true)
         XCTAssert(variantB.name == "TestB" && variantB.enabled == false)
         XCTAssert(variantC.name == "disabled") // change this to empty variant - name: disabled - enabled: false - empty payload
-        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])];
+        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])];
         XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics);
         
     }
@@ -179,7 +179,7 @@ final class unleash_proxy_client_base_swiftTests: XCTestCase {
         XCTAssert(variantA.name == "TestA" && variantA.enabled == true)
         XCTAssert(variantB.name == "TestB" && variantB.enabled == false)
         XCTAssert(variantC.name == "disabled") // change this to empty variant - name: disabled - enabled: false - empty payload
-        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 0, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])];
+        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])];
         XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics);
         
     }


### PR DESCRIPTION
## Feat: Add Impression Event Support

**Description:**

This PR introduces support for Impression Events in the Swift Proxy Client SDK. Impression events allow users to track when specific feature toggles are checked (i.e., "exposed" to a user), providing valuable data for analytics and understanding feature usage, separate from standard metrics.

This implementation focuses on emitting events when `isEnabled` or `getVariant` is called for a toggle that has the new `impressionData` flag set to `true`.

**Key Changes:**

*   **`Toggle` Struct:**
    *   Added a new boolean field `impressionData` (defaults to `false`).
    *   Implemented a custom `Decodable` initializer (`init(from decoder: Decoder)`) for `Toggle`. This ensures backward compatibility by handling JSON data that does not contain the `impressionData` field, defaulting it to `false` during decoding. This resolved numerous test failures related to bootstrapping and decoding older test data.
*   **`ImpressionEvent` Struct:**
    *   Added a new `ImpressionEvent` struct (`Sources/UnleashProxyClientSwift/Events/ImpressionEvent.swift`) to encapsulate the data for an impression event (toggle name, enabled status, variant info, context).
*   **`UnleashEvent` Enum:**
    *   Added a new `impression` case to the `UnleashEvent` enum (`Sources/UnleashProxyClientSwift/DTO/UnleashEvent.swift`).
*   **`UnleashClient` Modifications:**
    *   Updated `isEnabled(name:)` and `getVariant(name:)` methods to check the `impressionData` flag on the evaluated toggle.
    *   If `impressionData` is `true`, an `ImpressionEvent` object is created and posted via `SwiftEventBus.post("impression", sender: impressionEvent)`.
*   **New `subscribe` Overload:**
    *   Added new overloaded `subscribe` methods (`subscribe(_:callback:)` and `subscribe(name:callback:)`) to `UnleashClient`.
    *   These new methods accept a callback signature of `@escaping (Any?) -> Void`, allowing subscribers to receive the actual event object (e.g., the `ImpressionEvent` instance) passed as the `sender` in `SwiftEventBus.post`.
    *   The original `subscribe` methods (with `() -> Void` callbacks) are retained for backward compatibility.

**Testing:**

*   Added a new test suite `ImpressionEventsTests.swift`.
*   Tests cover scenarios for toggles with and without `impressionData`, toggles with variants, and non-existent toggles.
*   Tests were refactored to use the new `subscribe` overload that provides the event object.
*   Tests utilize a local `setup` helper function with `MockPoller` and `MockMetrics` for isolation and control.
