### PR TITLE
feat: default session id

### DIFF
--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -64,7 +64,7 @@ public class UnleashClientBase {
         
         self.context = Context(appName: appName, environment: environment, sessionId: String(Int.random(in: 0..<1_000_000_000)))
         if let providedContext = context {
-           self.context = self.calculateContext(context: providedContext)
+            self.context = self.calculateContext(context: providedContext)
         }
     }
 

--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -63,9 +63,8 @@ public class UnleashClientBase {
         }
         
         self.context = Context(appName: appName, environment: environment)
-        if let providedContext = context {
-            self.context = self.calculateContext(context: providedContext)
-        }
+        let providedContext = context ?? [:]
+        self.context = self.calculateContext(context: providedContext)
     }
 
     public func start(
@@ -192,12 +191,14 @@ public class UnleashClientBase {
         properties?.forEach { (key, value) in
             newProperties[key] = value
         }
+
+        let sessionId = context["sessionId"] ?? String(Int.random(in: 0..<1_000_000_000))
         
         let newContext = Context(
             appName: self.context.appName,
             environment: self.context.environment,
             userId: context["userId"],
-            sessionId: context["sessionId"],
+            sessionId: sessionId,
             remoteAddress: context["remoteAddress"],
             properties: newProperties
         )

--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -62,9 +62,10 @@ public class UnleashClientBase {
             self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey, customHeaders: customHeaders, connectionId: connectionId)
         }
         
-        self.context = Context(appName: appName, environment: environment)
-        let providedContext = context ?? [:]
-        self.context = self.calculateContext(context: providedContext)
+        self.context = Context(appName: appName, environment: environment, sessionId: String(Int.random(in: 0..<1_000_000_000)))
+          if let providedContext = context {
+            self.context = self.calculateContext(context: providedContext)
+          }
     }
 
     public func start(
@@ -192,7 +193,7 @@ public class UnleashClientBase {
             newProperties[key] = value
         }
 
-        let sessionId = context["sessionId"] ?? String(Int.random(in: 0..<1_000_000_000))
+        let sessionId = context["sessionId"] ?? self.context.sessionId;
         
         let newContext = Context(
             appName: self.context.appName,

--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -64,7 +64,7 @@ public class UnleashClientBase {
         
         self.context = Context(appName: appName, environment: environment, sessionId: String(Int.random(in: 0..<1_000_000_000)))
         if let providedContext = context {
-          self.context = self.calculateContext(context: providedContext)
+           self.context = self.calculateContext(context: providedContext)
         }
     }
 

--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -63,9 +63,9 @@ public class UnleashClientBase {
         }
         
         self.context = Context(appName: appName, environment: environment, sessionId: String(Int.random(in: 0..<1_000_000_000)))
-          if let providedContext = context {
-            self.context = self.calculateContext(context: providedContext)
-          }
+        if let providedContext = context {
+          self.context = self.calculateContext(context: providedContext)
+        }
     }
 
     public func start(

--- a/Sources/UnleashProxyClientSwift/Version/Version.swift
+++ b/Sources/UnleashProxyClientSwift/Version/Version.swift
@@ -1,3 +1,3 @@
 public struct LibraryInfo {
-    public static let version = "2.1.0"  // Update this string with each new release
+    public static let version = "2.2.0"  // Update this string with each new release
 }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashClientIntegrationTest.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashClientIntegrationTest.swift
@@ -12,7 +12,7 @@ class UnleashIntegrationTests: XCTestCase {
             clientKey: "SDKIntegration:development.f0474f4a37e60794ee8fb00a4c112de58befde962af6d5055b383ea3",
             refreshInterval: 15,
             appName: "testIntegration",
-            context: ["clientId": "disabled"]
+            context: ["clientId": "disabled", "sessionId": "1234"]
         )
     }
 
@@ -23,7 +23,7 @@ class UnleashIntegrationTests: XCTestCase {
     func testUserJourneyHappyPath() {
         let expectation = self.expectation(description: "Waiting for client updates")
         
-        XCTAssertEqual(unleashClient.context.toMap(), ["environment": "default", "clientId": "disabled", "appName": "testIntegration"])
+        XCTAssertEqual(unleashClient.context.toMap(), ["environment": "default", "clientId": "disabled", "appName": "testIntegration", "sessionId": "1234"])
 
         unleashClient.subscribe(name: "ready", callback: {
             XCTAssertFalse(self.unleashClient.isEnabled(name: self.featureName), "Feature should be disabled")
@@ -59,7 +59,7 @@ class UnleashIntegrationTests: XCTestCase {
     func testUserJourneyHappyPathWithUnleashEvent() {
         let expectation = self.expectation(description: "Waiting for client updates")
         
-        XCTAssertEqual(unleashClient.context.toMap(), ["environment": "default", "clientId": "disabled", "appName": "testIntegration"])
+        XCTAssertEqual(unleashClient.context.toMap(), ["environment": "default", "clientId": "disabled", "appName": "testIntegration", "sessionId": "1234"])
 
         unleashClient.subscribe(.ready) {
             XCTAssertFalse(self.unleashClient.isEnabled(name: self.featureName), "Feature should be disabled")


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Provide default session id if there's no session id from the user context. The session is is only consistent within the same process. To persist session across different process runs we'd need to put it into a storage. Our storage is only working with flags for now so it's a bigger change.
The reason why the in-process stable session is still valuable is the reduction of 200 requests and increase of 304s instead. With no fixed session any multi variant flag invalidates the cache since you may get assigned variant a or b on each request. 

Closes https://github.com/Unleash/unleash-proxy-client-swift/issues/119

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
