### PR TITLE
feat: add sdk flavor metadata

### DIFF
--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -38,7 +38,9 @@ public class UnleashClientBase {
         metrics: Metrics? = nil,
         customHeaders: [String: String] = [:],
         customHeadersProvider: CustomHeadersProvider = DefaultCustomHeadersProvider(),
-        bootstrap: Bootstrap = .toggles([])
+        bootstrap: Bootstrap = .toggles([]),
+        sdkFlavor: String? = nil,
+        sdkFlavorVersion: String? = nil
     ) {
         guard let url = URL(string: unleashUrl), url.scheme != nil else {
             fatalError("Invalid Unleash URL: \(unleashUrl)")
@@ -58,7 +60,9 @@ public class UnleashClientBase {
                 customHeadersProvider: customHeadersProvider,
                 bootstrap: bootstrap,
                 appName: appName,
-                connectionId: connectionId
+                connectionId: connectionId,
+                sdkFlavor: sdkFlavor,
+                sdkFlavorVersion: sdkFlavorVersion
             )
         }
         if let metrics = metrics {
@@ -74,7 +78,7 @@ public class UnleashClientBase {
                 }
                 task.resume()
             }
-            self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey, customHeaders: customHeaders, connectionId: connectionId)
+            self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey, customHeaders: customHeaders, connectionId: connectionId, sdkFlavor: sdkFlavor)
         }
 
         self._context = Context(appName: appName, environment: environment, sessionId: String(Int.random(in: 0..<1_000_000_000)))

--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -78,7 +78,7 @@ public class UnleashClientBase {
                 }
                 task.resume()
             }
-            self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey, customHeaders: customHeaders, connectionId: connectionId, sdkFlavor: sdkFlavor)
+            self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey, customHeaders: customHeaders, connectionId: connectionId, sdkFlavor: sdkFlavor, sdkFlavorVersion: sdkFlavorVersion)
         }
 
         self._context = Context(appName: appName, environment: environment, sessionId: String(Int.random(in: 0..<1_000_000_000)))

--- a/Sources/UnleashProxyClientSwift/Metrics/Metrics.swift
+++ b/Sources/UnleashProxyClientSwift/Metrics/Metrics.swift
@@ -14,18 +14,24 @@ public class Metrics {
     let url: URL
     let customHeaders: [String: String]
     let connectionId: UUID
+    let sdkFlavor: String?
+    let sdkFlavorVersion: String?
 
     private let lock = NSLock()
 
-    init(appName: String,
-         metricsInterval: TimeInterval,
-         clock: @escaping () -> Date,
-         disableMetrics: Bool = false,
-         poster: @escaping PosterHandler,
-         url: URL,
-         clientKey: String,
-         customHeaders: [String: String] = [:],
-         connectionId: UUID) {
+    init(
+        appName: String,
+        metricsInterval: TimeInterval,
+        clock: @escaping () -> Date,
+        disableMetrics: Bool = false,
+        poster: @escaping PosterHandler,
+        url: URL,
+        clientKey: String,
+        customHeaders: [String: String] = [:],
+        connectionId: UUID,
+        sdkFlavor: String? = nil,
+        sdkFlavorVersion: String? = nil
+        ) {
         self.appName = appName
         self.metricsInterval = metricsInterval
         self.clock = clock
@@ -36,6 +42,8 @@ public class Metrics {
         self.bucket = Bucket(clock: clock)
         self.customHeaders = customHeaders
         self.connectionId = connectionId
+        self.sdkFlavor = sdkFlavor
+        self.sdkFlavorVersion = sdkFlavorVersion
     }
 
     func start() {
@@ -146,6 +154,10 @@ public class Metrics {
         request.addValue(appName, forHTTPHeaderField: "unleash-appname")
         request.addValue(connectionId.uuidString, forHTTPHeaderField: "unleash-connection-id")
         request.setValue("unleash-ios-sdk:\(LibraryInfo.version)", forHTTPHeaderField: "unleash-sdk")
+        if let sdkFlavor {
+            request.setValue(sdkFlavor, forHTTPHeaderField: "unleash-sdk-flavor")
+            request.setValue(sdkFlavorVersion, forHTTPHeaderField: LibraryInfo.version)
+        }
         if !customHeaders.isEmpty {
             for (key, value) in customHeaders {
                 request.setValue(value, forHTTPHeaderField: key)

--- a/Sources/UnleashProxyClientSwift/Metrics/Metrics.swift
+++ b/Sources/UnleashProxyClientSwift/Metrics/Metrics.swift
@@ -156,7 +156,9 @@ public class Metrics {
         request.setValue("unleash-ios-sdk:\(LibraryInfo.version)", forHTTPHeaderField: "unleash-sdk")
         if let sdkFlavor {
             request.setValue(sdkFlavor, forHTTPHeaderField: "unleash-sdk-flavor")
-            request.setValue(sdkFlavorVersion, forHTTPHeaderField: LibraryInfo.version)
+        }
+        if let sdkFlavorVersion {
+            request.setValue(sdkFlavorVersion, forHTTPHeaderField: "unleash-sdk-flavor-version")
         }
         if !customHeaders.isEmpty {
             for (key, value) in customHeaders {

--- a/Sources/UnleashProxyClientSwift/Poller/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/Poller.swift
@@ -15,6 +15,8 @@ public class Poller {
     var storageProvider: StorageProvider
     let customHeaders: [String: String]
     let customHeadersProvider: CustomHeadersProvider
+    let sdkFlavor: String?
+    let sdkFlavorVersion: String?
 
     private let lock = NSLock()
 
@@ -28,7 +30,9 @@ public class Poller {
         customHeadersProvider: CustomHeadersProvider = DefaultCustomHeadersProvider(),
         bootstrap: Bootstrap = .toggles([]),
         appName: String,
-        connectionId: UUID
+        connectionId: UUID,
+        sdkFlavor: String? = nil,
+        sdkFlavorVersion: String? = nil
     ) {
         self.refreshInterval = refreshInterval
         self.unleashUrl = unleashUrl
@@ -42,6 +46,8 @@ public class Poller {
         self.storageProvider = storageProvider
         self.customHeaders = customHeaders
         self.customHeadersProvider = customHeadersProvider
+        self.sdkFlavor = sdkFlavor
+        self.sdkFlavorVersion = sdkFlavorVersion
 
         let toggles = bootstrap.toggles
         if toggles.isEmpty == false {
@@ -145,6 +151,10 @@ public class Poller {
         request.setValue(appName, forHTTPHeaderField: "unleash-appname")
         request.setValue(connectionId.uuidString, forHTTPHeaderField: "unleash-connection-id")
         request.setValue("unleash-ios-sdk:\(LibraryInfo.version)", forHTTPHeaderField: "unleash-sdk")
+        if let sdkFlavor {
+            request.setValue(sdkFlavor, forHTTPHeaderField: "unleash-ios-sdk-flavor")
+            request.setValue(sdkFlavorVersion, forHTTPHeaderField: LibraryInfo.version)
+        }
 
         let customHeaders = self.customHeaders.merging(self.customHeadersProvider.getCustomHeaders()) { (_, new) in
             new

--- a/Sources/UnleashProxyClientSwift/Poller/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/Poller.swift
@@ -152,8 +152,10 @@ public class Poller {
         request.setValue(connectionId.uuidString, forHTTPHeaderField: "unleash-connection-id")
         request.setValue("unleash-ios-sdk:\(LibraryInfo.version)", forHTTPHeaderField: "unleash-sdk")
         if let sdkFlavor {
-            request.setValue(sdkFlavor, forHTTPHeaderField: "unleash-ios-sdk-flavor")
-            request.setValue(sdkFlavorVersion, forHTTPHeaderField: LibraryInfo.version)
+            request.setValue(sdkFlavor, forHTTPHeaderField: "unleash-sdk-flavor")
+        }
+        if let sdkFlavorVersion {
+            request.setValue(sdkFlavorVersion, forHTTPHeaderField: "unleash-sdk-flavor-version")
         }
 
         let customHeaders = self.customHeaders.merging(self.customHeadersProvider.getCustomHeaders()) { (_, new) in

--- a/Tests/UnleashProxyClientSwiftTests/MetricsTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MetricsTests.swift
@@ -5,6 +5,11 @@ import SwiftEventBus
 @testable import UnleashProxyClientSwift
 
 final class MetricsTests: XCTestCase {
+    override func tearDown() {
+        SwiftEventBus.unregister(self)
+        super.tearDown()
+    }
+
     func testCountMetrics() throws {
         let metricsSent = expectation(description: "Metrics sent")
         SwiftEventBus.onBackgroundThread(self, name: "sent") { _ in

--- a/Tests/UnleashProxyClientSwiftTests/MetricsTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MetricsTests.swift
@@ -103,8 +103,8 @@ final class MetricsTests: XCTestCase {
         var recordedFlavor: String?
         var recordedFlavorVersion: String?
         let poster: Metrics.PosterHandler = { request, completionHandler in
-            recordedFlavor = request.value(forHTTPHeaderField: "sdkFlavor")
-            recordedFlavorVersion = request.value(forHTTPHeaderField: "sdkFlavorVersion")
+            recordedFlavor = request.value(forHTTPHeaderField: "unleash-sdk-flavor")
+            recordedFlavorVersion = request.value(forHTTPHeaderField: "unleash-sdk-flavor-version")
             let response = HTTPURLResponse(url: URL(string: "https://unleashapi.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
             completionHandler(.success((Data(), response!)))
         }
@@ -116,7 +116,7 @@ final class MetricsTests: XCTestCase {
                 url: URL(string: "https://unleashinstance.com")!,
                 clientKey: "testKey",
                 connectionId: UUID(),
-                sdkFlavor: "unleash-openfeature-swift-provider:1.0.0",
+                sdkFlavor: "unleash-openfeature-swift-provider",
                 sdkFlavorVersion: "1.0.0"
                 )
         metrics.start()
@@ -124,7 +124,7 @@ final class MetricsTests: XCTestCase {
 
         wait(for: [metricsSent], timeout: 2)
 
-        XCTAssertEqual(recordedFlavor, "unleash-openfeature-swift-provider:1.0.0")
+        XCTAssertEqual(recordedFlavor, "unleash-openfeature-swift-provider")
         XCTAssertEqual(recordedFlavorVersion, "1.0.0")
     }
 

--- a/Tests/UnleashProxyClientSwiftTests/MetricsTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MetricsTests.swift
@@ -94,6 +94,68 @@ final class MetricsTests: XCTestCase {
         wait(for: [metricsSentError], timeout: 2)
     }
 
+    func testSendsSdkFlavorHeaderWhenSet() throws {
+        let metricsSent = expectation(description: "Metrics sent")
+        SwiftEventBus.onBackgroundThread(self, name: "sent") { _ in
+            metricsSent.fulfill()
+        }
+
+        var recordedFlavor: String?
+        var recordedFlavorVersion: String?
+        let poster: Metrics.PosterHandler = { request, completionHandler in
+            recordedFlavor = request.value(forHTTPHeaderField: "sdkFlavor")
+            recordedFlavorVersion = request.value(forHTTPHeaderField: "sdkFlavorVersion")
+            let response = HTTPURLResponse(url: URL(string: "https://unleashapi.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            completionHandler(.success((Data(), response!)))
+        }
+
+        let metrics = Metrics(appName: "TestApp",
+                metricsInterval: 1,
+                clock: { Date() },
+                poster: poster,
+                url: URL(string: "https://unleashinstance.com")!,
+                clientKey: "testKey",
+                connectionId: UUID(),
+                sdkFlavor: "unleash-openfeature-swift-provider:1.0.0",
+                sdkFlavorVersion: "1.0.0"
+                )
+        metrics.start()
+        metrics.count(name: "testToggle", enabled: true)
+
+        wait(for: [metricsSent], timeout: 2)
+
+        XCTAssertEqual(recordedFlavor, "unleash-openfeature-swift-provider:1.0.0")
+        XCTAssertEqual(recordedFlavorVersion, "1.0.0")
+    }
+
+    func testOmitsSdkFlavorHeaderWhenUnset() throws {
+        let metricsSent = expectation(description: "Metrics sent")
+        SwiftEventBus.onBackgroundThread(self, name: "sent") { _ in
+            metricsSent.fulfill()
+        }
+
+        var flavorHeaderPresent = true
+        let poster: Metrics.PosterHandler = { request, completionHandler in
+            flavorHeaderPresent = request.value(forHTTPHeaderField: "unleash-sdk-flavor") != nil
+            let response = HTTPURLResponse(url: URL(string: "https://unleashapi.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            completionHandler(.success((Data(), response!)))
+        }
+
+        let metrics = Metrics(appName: "TestApp",
+                metricsInterval: 1,
+                clock: { Date() },
+                poster: poster,
+                url: URL(string: "https://unleashinstance.com")!,
+                clientKey: "testKey",
+                connectionId: UUID())
+        metrics.start()
+        metrics.count(name: "testToggle", enabled: true)
+
+        wait(for: [metricsSent], timeout: 2)
+
+        XCTAssertFalse(flavorHeaderPresent)
+    }
+
     func testDisabledMetrics() throws {
         let fixedClock = { DateComponents(calendar: .current, timeZone: TimeZone(identifier: "UTC"), year: 2022, month: 12, day: 24, hour: 23, minute: 0, second: 0).date! }
 


### PR DESCRIPTION
We add SDK flavour and flavour version metadata to the metrics. 

Useful for OpenFeature providers, so that they are not confused with the base SDK in our metrics, and we can track their usage.