### PR TITLE
refactor: apply linter to fix issues

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "UnleashProxyClientSwift",
-            targets: ["UnleashProxyClientSwift"]),
+            targets: ["UnleashProxyClientSwift"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/cesarferreira/SwiftEventBus.git", from: "5.1.0"),
@@ -31,9 +32,8 @@ let package = Package(
             name: "UnleashProxyClientSwiftTests",
             dependencies: ["UnleashProxyClientSwift"],
             resources: [
-                .copy("FeatureResponseStub.json")
+                .copy("FeatureResponseStub.json"),
             ]
         ),
-        
     ]
 )

--- a/Sources/UnleashProxyClientSwift/Client/Bootstrap.swift
+++ b/Sources/UnleashProxyClientSwift/Client/Bootstrap.swift
@@ -3,18 +3,18 @@ import Foundation
 public enum Bootstrap {
     /// Provide a list of Toggles
     case toggles([Toggle])
-    
+
     /// Provide a path to json file describing toggles
     ///
     /// > Important: If the file cannot be opened it will log error to console and default to an empty list of toggles
     case jsonFile(path: String)
-    
+
     var toggles: [Toggle] {
         switch self {
-        case .toggles(let toggles):
+        case let .toggles(toggles):
             return toggles
-            
-        case .jsonFile(let path):
+
+        case let .jsonFile(path):
             do {
                 let data = try Data(contentsOf: URL(fileURLWithPath: path))
                 let decodedData: FeatureResponse = try JSONDecoder()

--- a/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
+++ b/Sources/UnleashProxyClientSwift/Client/UnleashProxyClientSwift.swift
@@ -6,18 +6,19 @@ public class UnleashClientBase {
     private var _context: Context
 
     public var context: Context {
-            get {
-                lock.lock()
-                let value = self._context
-                lock.unlock()
-                return value
-            }
-            set {
-                lock.lock()
-                self._context = newValue
-                lock.unlock()
-            }
+        get {
+            lock.lock()
+            let value = _context
+            lock.unlock()
+            return value
         }
+        set {
+            lock.lock()
+            _context = newValue
+            lock.unlock()
+        }
+    }
+
     var timer: DispatchSourceTimer?
     var poller: Poller
     var metrics: Metrics
@@ -44,8 +45,8 @@ public class UnleashClientBase {
             fatalError("Invalid Unleash URL: \(unleashUrl)")
         }
 
-        self.connectionId = UUID()
-        self.timer = nil
+        connectionId = UUID()
+        timer = nil
         if let poller = poller {
             self.poller = poller
         } else {
@@ -65,7 +66,7 @@ public class UnleashClientBase {
             self.metrics = metrics
         } else {
             let urlSessionPoster: Metrics.PosterHandler = { request, completionHandler in
-                let task = URLSession.shared.dataTask(with: request) { (data, response, error) in
+                let task = URLSession.shared.dataTask(with: request) { data, response, error in
                     if let error = error {
                         completionHandler(.failure(error))
                     } else if let data = data, let response = response {
@@ -74,12 +75,12 @@ public class UnleashClientBase {
                 }
                 task.resume()
             }
-            self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { return Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey, customHeaders: customHeaders, connectionId: connectionId)
+            self.metrics = Metrics(appName: appName, metricsInterval: Double(metricsInterval), clock: { Date() }, disableMetrics: disableMetrics, poster: urlSessionPoster, url: url, clientKey: clientKey, customHeaders: customHeaders, connectionId: connectionId)
         }
 
-        self._context = Context(appName: appName, environment: environment, sessionId: String(Int.random(in: 0..<1_000_000_000)))
+        _context = Context(appName: appName, environment: environment, sessionId: String(Int.random(in: 0 ..< 1_000_000_000)))
         if let providedContext = context {
-            self._context = self.calculateContext(context: providedContext)
+            _context = calculateContext(context: providedContext)
         }
     }
 
@@ -87,9 +88,9 @@ public class UnleashClientBase {
         bootstrap: Bootstrap = .toggles([]),
         _ printToConsole: Bool = false,
         completionHandler: ((PollerError?) -> Void)? = nil
-    ) -> Void {
+    ) {
         Printer.showPrintStatements = printToConsole
-        self.stopPolling()
+        stopPolling()
         poller.start(
             bootstrapping: bootstrap.toggles,
             context: context,
@@ -98,13 +99,13 @@ public class UnleashClientBase {
         metrics.start()
     }
 
-    private func stopPolling() -> Void {
+    private func stopPolling() {
         poller.stop()
         metrics.stop()
     }
 
-    public func stop() -> Void {
-        self.stopPolling()
+    public func stop() {
+        stopPolling()
         lock.lock()
         timer?.cancel()
         timer = nil
@@ -115,7 +116,7 @@ public class UnleashClientBase {
     public func isEnabled(name: String) -> Bool {
         let toggle = poller.getFeature(name: name)
         let enabled = toggle?.enabled ?? false
-        let contextSnapshot = self.context
+        let contextSnapshot = context
 
         metrics.count(name: name, enabled: enabled)
 
@@ -136,7 +137,7 @@ public class UnleashClientBase {
         let toggle = poller.getFeature(name: name)
         let variant = toggle?.variant ?? .defaultDisabled
         let enabled = toggle?.enabled ?? false
-        let contextSnapshot = self.context
+        let contextSnapshot = context
 
         metrics.count(name: name, enabled: enabled)
         metrics.countVariant(name: name, variant: variant.name)
@@ -158,12 +159,12 @@ public class UnleashClientBase {
     public func subscribe(name: String, callback: @escaping () -> Void) {
         if Thread.isMainThread {
             print("Subscribing to \(name) on main thread")
-            SwiftEventBus.onMainThread(self, name: name) { result in
+            SwiftEventBus.onMainThread(self, name: name) { _ in
                 callback()
             }
         } else {
             print("Subscribing to \(name) on background thread")
-            SwiftEventBus.onBackgroundThread(self, name: name) { result in
+            SwiftEventBus.onBackgroundThread(self, name: name) { _ in
                 callback()
             }
         }
@@ -204,7 +205,7 @@ public class UnleashClientBase {
         properties: [String: String]? = nil,
         completionHandler: ((PollerError?) -> Void)? = nil
     ) {
-        let newContext = self.calculateContext(context: context, properties: properties)
+        let newContext = calculateContext(context: context, properties: properties)
         self.context = newContext
 
         DispatchQueue.global(qos: .background).async {
@@ -212,25 +213,25 @@ public class UnleashClientBase {
         }
     }
 
-    func calculateContext(context: [String: String], properties: [String:String]? = nil) -> Context {
+    func calculateContext(context: [String: String], properties: [String: String]? = nil) -> Context {
         let specialKeys: Set = ["appName", "environment", "userId", "sessionId", "remoteAddress"]
         var newProperties: [String: String] = [:]
 
-        context.forEach { (key, value) in
+        for (key, value) in context {
             if !specialKeys.contains(key) {
                 newProperties[key] = value
             }
         }
 
-        properties?.forEach { (key, value) in
+        properties?.forEach { key, value in
             newProperties[key] = value
         }
 
         let currentContext = self.context
 
-        let sessionId = context["sessionId"] ?? currentContext.sessionId;
+        let sessionId = context["sessionId"] ?? currentContext.sessionId
 
-        let newContext = Context(
+        return Context(
             appName: currentContext.appName,
             environment: currentContext.environment,
             userId: context["userId"],
@@ -238,8 +239,6 @@ public class UnleashClientBase {
             remoteAddress: context["remoteAddress"],
             properties: newProperties
         )
-
-        return newContext
     }
 }
 
@@ -264,7 +263,7 @@ public class UnleashClient: UnleashClientBase, ObservableObject {
     @MainActor
     public func updateContext(
         context: [String: String],
-        properties: [String:String]? = nil
+        properties: [String: String]? = nil
     ) async throws {
         return try await withCheckedThrowingContinuation { continuation in
             updateContext(context: context, properties: properties) { error in

--- a/Sources/UnleashProxyClientSwift/DTO/Context.swift
+++ b/Sources/UnleashProxyClientSwift/DTO/Context.swift
@@ -5,7 +5,7 @@ public struct Context {
     var sessionId: String?
     var remoteAddress: String?
     var properties: [String: String]?
-    
+
     init(
         appName: String? = nil,
         environment: String? = nil,
@@ -21,49 +21,49 @@ public struct Context {
         self.remoteAddress = remoteAddress
         self.properties = properties
     }
-    
+
     public func toMap() -> [String: String] {
         var params: [String: String] = [:]
-        properties?.forEach { (key, value) in
+        properties?.forEach { key, value in
             params[key] = value
         }
-        if let userId = self.userId {
+        if let userId = userId {
             params["userId"] = userId
         }
-        if let remoteAddress = self.remoteAddress {
+        if let remoteAddress = remoteAddress {
             params["remoteAddress"] = remoteAddress
         }
-        if let sessionId = self.sessionId {
+        if let sessionId = sessionId {
             params["sessionId"] = sessionId
         }
-        if let appName = self.appName {
+        if let appName = appName {
             params["appName"] = appName
         }
-        if let environment = self.environment {
+        if let environment = environment {
             params["environment"] = environment
         }
-        
+
         return params
     }
-    
+
     func toURIMap() -> [String: String] {
         var params: [String: String] = [:]
-        if let userId = self.userId {
+        if let userId = userId {
             params["userId"] = userId
         }
-        if let remoteAddress = self.remoteAddress {
+        if let remoteAddress = remoteAddress {
             params["remoteAddress"] = remoteAddress
         }
-        if let sessionId = self.sessionId {
+        if let sessionId = sessionId {
             params["sessionId"] = sessionId
         }
-        if let appName = self.appName {
+        if let appName = appName {
             params["appName"] = appName
         }
-        if let environment = self.environment {
+        if let environment = environment {
             params["environment"] = environment
         }
-        properties?.forEach { (key, value) in
+        properties?.forEach { key, value in
             params["properties[\(key)]"] = value
         }
         return params

--- a/Sources/UnleashProxyClientSwift/DTO/FeatureResponse.swift
+++ b/Sources/UnleashProxyClientSwift/DTO/FeatureResponse.swift
@@ -1,4 +1,5 @@
 // MARK: - Response
+
 struct FeatureResponse: Codable {
     let toggles: [Toggle]
 }

--- a/Sources/UnleashProxyClientSwift/DTO/Payload.swift
+++ b/Sources/UnleashProxyClientSwift/DTO/Payload.swift
@@ -1,7 +1,8 @@
 // MARK: - Payload
+
 public struct Payload: Codable, Equatable {
     public let type, value: String
-    
+
     public init(type: String, value: String) {
         self.type = type
         self.value = value

--- a/Sources/UnleashProxyClientSwift/DTO/Toggle.swift
+++ b/Sources/UnleashProxyClientSwift/DTO/Toggle.swift
@@ -1,10 +1,11 @@
 // MARK: - Toggle
+
 public struct Toggle: Codable, Equatable {
     public let name: String
     public let enabled: Bool
     public let impressionData: Bool
     public let variant: Variant?
-    
+
     public init(
         name: String,
         enabled: Bool,
@@ -16,14 +17,14 @@ public struct Toggle: Codable, Equatable {
         self.impressionData = impressionData
         self.variant = variant
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case name
         case enabled
         case impressionData
         case variant
     }
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)

--- a/Sources/UnleashProxyClientSwift/DTO/UnleashEvent.swift
+++ b/Sources/UnleashProxyClientSwift/DTO/UnleashEvent.swift
@@ -1,4 +1,5 @@
 // MARK: UnleashEvent
+
 public enum UnleashEvent: String, CaseIterable {
     /// Emitted when UnleashClient is ready after finished first flag fetch
     case ready

--- a/Sources/UnleashProxyClientSwift/DTO/Variant.swift
+++ b/Sources/UnleashProxyClientSwift/DTO/Variant.swift
@@ -1,10 +1,11 @@
 // MARK: - Variant
+
 public struct Variant: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case name, enabled, payload
         case featureEnabled = "feature_enabled"
     }
-    
+
     /// Name of the variant
     public let name: String
     /// Enabled state for the variant
@@ -17,7 +18,7 @@ public struct Variant: Codable, Equatable {
     public let featureEnabled: Bool?
     /// Optional payload delivered with the variant
     public let payload: Payload?
-    
+
     public init(
         name: String,
         enabled: Bool,

--- a/Sources/UnleashProxyClientSwift/Events/ImpressionEvent.swift
+++ b/Sources/UnleashProxyClientSwift/Events/ImpressionEvent.swift
@@ -5,11 +5,11 @@ public struct ImpressionEvent {
     public let enabled: Bool
     public let variant: Variant?
     public let context: Context
-    
+
     public init(toggleName: String, enabled: Bool, variant: Variant? = nil, context: Context) {
         self.toggleName = toggleName
         self.enabled = enabled
         self.variant = variant
         self.context = context
     }
-} 
+}

--- a/Sources/UnleashProxyClientSwift/Metrics/Bucket.swift
+++ b/Sources/UnleashProxyClientSwift/Metrics/Bucket.swift
@@ -24,7 +24,7 @@ struct Bucket {
         return [
             "start": start.iso8601String(),
             "stop": stop?.iso8601String() ?? "",
-            "toggles": mappedToggles
+            "toggles": mappedToggles,
         ]
     }
 }

--- a/Sources/UnleashProxyClientSwift/Metrics/Metrics.swift
+++ b/Sources/UnleashProxyClientSwift/Metrics/Metrics.swift
@@ -25,7 +25,8 @@ public class Metrics {
          url: URL,
          clientKey: String,
          customHeaders: [String: String] = [:],
-         connectionId: UUID) {
+         connectionId: UUID)
+    {
         self.appName = appName
         self.metricsInterval = metricsInterval
         self.clock = clock
@@ -33,22 +34,24 @@ public class Metrics {
         self.poster = poster
         self.url = url
         self.clientKey = clientKey
-        self.bucket = Bucket(clock: clock)
+        bucket = Bucket(clock: clock)
         self.customHeaders = customHeaders
         self.connectionId = connectionId
     }
 
     func start() {
         lock.lock()
-        let isDisabled = self.disableMetrics
+        let isDisabled = disableMetrics
         lock.unlock()
 
-        if isDisabled { return }
+        if isDisabled {
+            return
+        }
 
         lock.lock()
         self.timer?.cancel()
         self.timer = nil
-        let interval = self.metricsInterval
+        let interval = metricsInterval
         lock.unlock()
 
         let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .background))
@@ -66,14 +69,14 @@ public class Metrics {
 
     func stop() {
         lock.lock()
-        self.timer?.cancel()
-        self.timer = nil
+        timer?.cancel()
+        timer = nil
         lock.unlock()
     }
 
     func count(name: String, enabled: Bool) {
         lock.lock()
-        let isDisabled = self.disableMetrics
+        let isDisabled = disableMetrics
         if isDisabled {
             lock.unlock()
             return
@@ -91,7 +94,7 @@ public class Metrics {
 
     func countVariant(name: String, variant: String) {
         lock.lock()
-        let isDisabled = self.disableMetrics
+        let isDisabled = disableMetrics
         if isDisabled {
             lock.unlock()
             return
@@ -106,11 +109,11 @@ public class Metrics {
     func sendMetrics() {
         let localBucket: Bucket
         let clockFunction: () -> Date
-        
+
         lock.lock()
         bucket.closeBucket()
         localBucket = bucket
-        clockFunction = self.clock
+        clockFunction = clock
         bucket = Bucket(clock: clockFunction)
         lock.unlock()
 
@@ -122,9 +125,9 @@ public class Metrics {
             let request = createRequest(payload: jsonPayload)
             poster(request) { result in
                 switch result {
-                case .success(_):
+                case .success:
                     SwiftEventBus.post("sent")
-                case .failure(let error):
+                case let .failure(error):
                     Printer.printMessage("Error sending metrics")
                     SwiftEventBus.post("error", sender: error)
                 }

--- a/Sources/UnleashProxyClientSwift/Metrics/MetricsPayload.swift
+++ b/Sources/UnleashProxyClientSwift/Metrics/MetricsPayload.swift
@@ -7,7 +7,7 @@ struct MetricsPayload {
         [
             "appName": appName,
             "instanceId": instanceId,
-            "bucket": bucket.toJson()
+            "bucket": bucket.toJson(),
         ]
     }
 }

--- a/Sources/UnleashProxyClientSwift/Poller/DictionaryStorageProvider.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/DictionaryStorageProvider.swift
@@ -8,20 +8,20 @@ public class DictionaryStorageProvider: StorageProvider {
 
     public func set(values: [String: Toggle]) {
         lock.lock()
-        self.storage = values
+        storage = values
         lock.unlock()
     }
 
     public func value(key: String) -> Toggle? {
         lock.lock()
-        let result = self.storage[key]
+        let result = storage[key]
         lock.unlock()
         return result
     }
 
     public func clear() {
         lock.lock()
-        self.storage = [:]
+        storage = [:]
         lock.unlock()
     }
 }

--- a/Sources/UnleashProxyClientSwift/Poller/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/Poller.swift
@@ -6,10 +6,10 @@ public class Poller {
     var unleashUrl: URL
     var timer: DispatchSourceTimer?
     var ready: Bool
-    var apiKey: String;
-    var etag: String;
-    var appName: String;
-    var connectionId: UUID;
+    var apiKey: String
+    var etag: String
+    var appName: String
+    var connectionId: UUID
 
     private let session: PollerSession
     var storageProvider: StorageProvider
@@ -35,9 +35,9 @@ public class Poller {
         self.apiKey = apiKey
         self.appName = appName
         self.connectionId = connectionId
-        self.timer = nil
-        self.ready = false
-        self.etag = ""
+        timer = nil
+        ready = false
+        etag = ""
         self.session = session
         self.storageProvider = storageProvider
         self.customHeaders = customHeaders
@@ -55,14 +55,14 @@ public class Poller {
         completionHandler: ((PollerError?) -> Void)? = nil
     ) {
         if toggles.isEmpty {
-            self.getFeatures(context: context, completionHandler: completionHandler)
+            getFeatures(context: context, completionHandler: completionHandler)
         } else {
             Printer.printMessage("Starting with provided bootstrap toggles")
             createFeatureMap(toggles: toggles)
             completionHandler?(nil)
         }
 
-        let refreshIntervalValue = self.refreshInterval
+        let refreshIntervalValue = refreshInterval
 
         if refreshIntervalValue == 0 {
             return
@@ -85,20 +85,21 @@ public class Poller {
 
     public func stop() {
         lock.lock()
-        self.timer?.cancel()
-        self.timer = nil
+        timer?.cancel()
+        timer = nil
         lock.unlock()
     }
 
     func formatURL(context: Context) -> URL? {
-        let url = self.unleashUrl
+        let url = unleashUrl
 
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.percentEncodedQuery = context
             .toURIMap()
             .compactMap { key, value in
                 if let encodedKey = key.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved),
-                   let encodedValue = value.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved) {
+                   let encodedValue = value.addingPercentEncoding(withAllowedCharacters: .rfc3986Unreserved)
+                {
                     return [encodedKey, encodedValue].joined(separator: "=")
                 }
                 return nil
@@ -117,7 +118,7 @@ public class Poller {
     }
 
     public func getFeature(name: String) -> Toggle? {
-        return self.storageProvider.value(key: name)
+        return storageProvider.value(key: name)
     }
 
     func getFeatures(
@@ -135,9 +136,9 @@ public class Poller {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let currentEtag: String
-        
+
         lock.lock()
-        currentEtag = self.etag
+        currentEtag = etag
         lock.unlock()
 
         request.setValue(apiKey, forHTTPHeaderField: "Authorization")
@@ -146,7 +147,7 @@ public class Poller {
         request.setValue(connectionId.uuidString, forHTTPHeaderField: "unleash-connection-id")
         request.setValue("unleash-ios-sdk:\(LibraryInfo.version)", forHTTPHeaderField: "unleash-sdk")
 
-        let customHeaders = self.customHeaders.merging(self.customHeadersProvider.getCustomHeaders()) { (_, new) in
+        let customHeaders = self.customHeaders.merging(customHeadersProvider.getCustomHeaders()) { _, new in
             new
         }.filter { key, _ in !isSensitiveHeader(key) }
 
@@ -157,7 +158,7 @@ public class Poller {
         }
         request.cachePolicy = .reloadIgnoringLocalCacheData
 
-        session.perform(request) { [self] (data, response, error) in
+        session.perform(request) { [self] data, response, error in
             guard let httpResponse = response as? HTTPURLResponse else {
                 Printer.printMessage("No response")
                 completionHandler?(.noResponse)
@@ -170,7 +171,7 @@ public class Poller {
                 return
             }
 
-            if httpResponse.statusCode > 399 && httpResponse.statusCode < 599 {
+            if httpResponse.statusCode > 399, httpResponse.statusCode < 599 {
                 completionHandler?(.network)
                 Printer.printMessage("Error fetching toggles")
                 return
@@ -216,7 +217,7 @@ public class Poller {
                 self.ready = true
             }
             lock.unlock()
-            
+
             if wasReady {
                 Printer.printMessage("Flags updated")
                 SwiftEventBus.post("update")
@@ -232,11 +233,11 @@ public class Poller {
     private func isSensitiveHeader(_ header: String) -> Bool {
         let lowercasedHeader = header.lowercased()
         return lowercasedHeader == "content-type" ||
-               lowercasedHeader == "if-none-match" ||
-               lowercasedHeader.hasPrefix("unleash-")
+            lowercasedHeader == "if-none-match" ||
+            lowercasedHeader.hasPrefix("unleash-")
     }
 }
 
-fileprivate extension CharacterSet {
+private extension CharacterSet {
     static let rfc3986Unreserved = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
 }

--- a/Sources/UnleashProxyClientSwift/Utils/Printer.swift
+++ b/Sources/UnleashProxyClientSwift/Utils/Printer.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  Printer.swift
+//
 //
 //  Created by Daniel Chick on 11/2/22.
 //

--- a/Sources/UnleashProxyClientSwift/Utils/URLSession+Extensions.swift
+++ b/Sources/UnleashProxyClientSwift/Utils/URLSession+Extensions.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension URLSession: PollerSession {
     public func perform(_ request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
-        let task = dataTask(with: request) { (data, response, error) in
+        let task = dataTask(with: request) { data, response, error in
             completionHandler(data, response, error)
         }
         task.resume()

--- a/Sources/UnleashProxyClientSwift/Utils/utils.swift
+++ b/Sources/UnleashProxyClientSwift/Utils/utils.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  utils.swift
 //
 //
 //  Created by Fredrik Strand Oseberg on 13/05/2021.

--- a/Sources/UnleashProxyClientSwift/Version/Version.swift
+++ b/Sources/UnleashProxyClientSwift/Version/Version.swift
@@ -1,3 +1,3 @@
-public struct LibraryInfo {
-    public static let version = "2.4.0"  // Update this string with each new release
+public enum LibraryInfo {
+    public static let version = "2.4.0" // Update this string with each new release
 }

--- a/Tests/UnleashProxyClientSwiftTests/BootstrapTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/BootstrapTests.swift
@@ -1,6 +1,5 @@
-@testable import UnleashProxyClientSwift
-
 import Foundation
+@testable import UnleashProxyClientSwift
 import XCTest
 
 final class BootstrapTests: XCTestCase {
@@ -8,26 +7,25 @@ final class BootstrapTests: XCTestCase {
     func testTogglesWhenBootstrapToggles() {
         let stubToggle = Toggle(name: "foo", enabled: true)
         let bootstrap = Bootstrap.toggles([stubToggle])
-        
+
         XCTAssertEqual(bootstrap.toggles, [stubToggle])
     }
-    
-    
+
     /// GIVEN a Bootstrap jsonFile, WHEN file does not exist, THEN toggles returns empty array
     func testTogglesWhenJsonFileDoesNotExist() {
         let bootstrap = Bootstrap.jsonFile(path: "")
         XCTAssertTrue(bootstrap.toggles.isEmpty)
     }
-    
+
     /// GIVEN a Bootstrap jsonFile, WHEN file exists, THEN toggles returns expected toggles
     func testTogglesWhenJsonFileExists() throws {
         let path = try XCTUnwrap(
             Bundle.module
                 .path(forResource: "FeatureResponseStub", ofType: "json")
         )
-        
+
         let bootstrap = Bootstrap.jsonFile(path: path)
-        
+
         let expectedToggles = [
             Toggle(name: "no-variant", enabled: true, variant: nil),
             Toggle(
@@ -44,9 +42,9 @@ final class BootstrapTests: XCTestCase {
                     featureEnabled: true,
                     payload: .init(type: "string", value: "baz")
                 )
-            )
+            ),
         ]
-        
+
         XCTAssertEqual(bootstrap.toggles, expectedToggles)
     }
 }

--- a/Tests/UnleashProxyClientSwiftTests/ImpressionEventsTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/ImpressionEventsTests.swift
@@ -1,23 +1,23 @@
-import XCTest
 import SwiftEventBus
 @testable import UnleashProxyClientSwift
+import XCTest
 
 class ImpressionEventsTests: XCTestCase {
-    struct TestData {
+    enum TestData {
         static let toggleWithImpressionData = Toggle(
             name: "test-toggle-impression",
             enabled: true,
             impressionData: true,
             variant: nil
         )
-        
+
         static let toggleWithoutImpressionData = Toggle(
             name: "test-toggle-no-impression",
             enabled: true,
             impressionData: false,
             variant: nil
         )
-        
+
         static let toggleWithVariant = Toggle(
             name: "test-toggle-variant",
             enabled: true,
@@ -25,7 +25,7 @@ class ImpressionEventsTests: XCTestCase {
             variant: Variant(name: "test-variant", enabled: true)
         )
     }
-    
+
     func setup(toggles: [Toggle] = []) -> UnleashClient {
         let client = UnleashClient(
             unleashUrl: "https://test-setup.com",
@@ -35,54 +35,53 @@ class ImpressionEventsTests: XCTestCase {
         client.start(bootstrap: .toggles(toggles))
         return client
     }
-    
+
     func testImpressionEventEmittedWhenImpressionDataEnabled() {
         let toggle = TestData.toggleWithImpressionData
         let client = setup(toggles: [toggle])
         let expectation = XCTestExpectation(description: "Impression event received for enabled test")
-        
+
         client.subscribe(.impression) { object in
             guard let impressionEvent = object as? ImpressionEvent else {
                 XCTFail("Expected ImpressionEvent")
                 return
             }
-    
+
             XCTAssertEqual(impressionEvent.toggleName, toggle.name)
             XCTAssertEqual(impressionEvent.enabled, toggle.enabled)
 
             XCTAssertNil(impressionEvent.variant)
             expectation.fulfill()
         }
-        
+
         _ = client.isEnabled(name: toggle.name)
         wait(for: [expectation], timeout: 1.0)
-        client.stop();
+        client.stop()
     }
-    
+
     func testNoImpressionEventWhenImpressionDataDisabled() {
         let toggle = TestData.toggleWithoutImpressionData
         let client = setup(toggles: [toggle])
-        
+
         let expectation = XCTestExpectation(description: "No impression event expected")
         expectation.isInverted = true
         client.subscribe(.impression) { _ in expectation.fulfill() }
         _ = client.isEnabled(name: toggle.name)
         wait(for: [expectation], timeout: 0.1)
-        client.stop();
+        client.stop()
     }
-    
+
     func testImpressionEventWithVariantData() {
         let toggle = TestData.toggleWithVariant
         let client = setup(toggles: [toggle])
         let expectation = XCTestExpectation(description: "Impression event received for variant test")
-        
 
         client.subscribe(.impression) { object in
             guard let impressionEvent = object as? ImpressionEvent else {
                 XCTFail("Expected ImpressionEvent, got \(String(describing: object))")
                 return
             }
-            
+
             print("impressionEventVariant: \(impressionEvent)")
             print("impressionEvent.toggleName: \(impressionEvent.toggleName)")
             print("testData.toggleName: \(TestData.toggleWithVariant.name)")
@@ -92,21 +91,21 @@ class ImpressionEventsTests: XCTestCase {
             XCTAssertEqual(impressionEvent.variant?.name, toggle.variant?.name)
             expectation.fulfill()
         }
-        
+
         _ = client.getVariant(name: toggle.name)
         wait(for: [expectation], timeout: 1.0)
-        client.stop();
+        client.stop()
     }
-    
+
     func testNoImpressionEventWhenToggleNotFound() {
         let nonExistentToggle = "non-existent-toggle"
         let client = setup(toggles: [])
-    
+
         let expectation = XCTestExpectation(description: "No impression event expected")
         expectation.isInverted = true
         client.subscribe(.impression) { _ in expectation.fulfill() }
         _ = client.isEnabled(name: nonExistentToggle)
         wait(for: [expectation], timeout: 0.1)
-        client.stop();
+        client.stop()
     }
-} 
+}

--- a/Tests/UnleashProxyClientSwiftTests/MetricsTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MetricsTests.swift
@@ -1,8 +1,8 @@
 // MetricsTests.swift
 
-import XCTest
 import SwiftEventBus
 @testable import UnleashProxyClientSwift
+import XCTest
 
 final class MetricsTests: XCTestCase {
     func testCountMetrics() throws {
@@ -21,13 +21,13 @@ final class MetricsTests: XCTestCase {
             completionHandler(.success((Data(), response!)))
         }
 
-        let metrics = Metrics(appName: "TestApp",
-                metricsInterval: 1,
-                clock: fixedClock,
-                poster: poster,
-                url: URL(string: "https://unleashinstance.com")!,
-                clientKey: "testKey",
-                connectionId: UUID())
+        let metrics = try Metrics(appName: "TestApp",
+                                  metricsInterval: 1,
+                                  clock: fixedClock,
+                                  poster: poster,
+                                  url: XCTUnwrap(URL(string: "https://unleashinstance.com")),
+                                  clientKey: "testKey",
+                                  connectionId: UUID())
         metrics.start()
 
         metrics.count(name: "testToggle", enabled: true)
@@ -40,32 +40,32 @@ final class MetricsTests: XCTestCase {
         wait(for: [metricsSent], timeout: 2)
 
         let expectedMetrics = """
-                              {
-                                "appName" : "TestApp",
-                                "bucket" : {
-                                  "start" : "2022-12-24T23:00:00Z",
-                                  "stop" : "2022-12-24T23:00:00Z",
-                                  "toggles" : {
-                                    "testToggle" : {
-                                      "yes" : 2,
-                                      "no" : 1,
-                                      "variants" : {
-                                        "variantA" : 2,
-                                        "variantB": 1
-                                      }
-                                    }
-                                  }
-                                },
-                                "instanceId" : "swift"
-                              }
-                              """;
+        {
+          "appName" : "TestApp",
+          "bucket" : {
+            "start" : "2022-12-24T23:00:00Z",
+            "stop" : "2022-12-24T23:00:00Z",
+            "toggles" : {
+              "testToggle" : {
+                "yes" : 2,
+                "no" : 1,
+                "variants" : {
+                  "variantA" : 2,
+                  "variantB": 1
+                }
+              }
+            }
+          },
+          "instanceId" : "swift"
+        }
+        """
 
-        let decodedRecordedRequestBody = try JSONSerialization.jsonObject(with: recordedRequestBody!, options: [])
+        let decodedRecordedRequestBody = try JSONSerialization.jsonObject(with: XCTUnwrap(recordedRequestBody), options: [])
         let decodedExpectedMetrics = try JSONSerialization.jsonObject(with: Data(expectedMetrics.utf8), options: [])
 
         XCTAssertEqual(decodedRecordedRequestBody as? [String: AnyHashable],
-                decodedExpectedMetrics as? [String: AnyHashable],
-                "The recorded request body should match the expected metrics")
+                       decodedExpectedMetrics as? [String: AnyHashable],
+                       "The recorded request body should match the expected metrics")
     }
 
     func testFailOnCountMetricsSent() throws {
@@ -76,17 +76,17 @@ final class MetricsTests: XCTestCase {
 
         let fixedClock = { DateComponents(calendar: .current, timeZone: TimeZone(identifier: "UTC"), year: 2022, month: 12, day: 24, hour: 23, minute: 0, second: 0).date! }
 
-        let poster: Metrics.PosterHandler = { request, completionHandler in
-            completionHandler(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "Metrics posting error"])))
+        let poster: Metrics.PosterHandler = { _, completionHandler in
+            completionHandler(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Metrics posting error"])))
         }
 
-        let metrics = Metrics(appName: "TestApp",
-                metricsInterval: 1,
-                clock: fixedClock,
-                poster: poster,
-                url: URL(string: "https://unleashinstance.com")!,
-                clientKey: "testKey",
-                connectionId: UUID())
+        let metrics = try Metrics(appName: "TestApp",
+                                  metricsInterval: 1,
+                                  clock: fixedClock,
+                                  poster: poster,
+                                  url: XCTUnwrap(URL(string: "https://unleashinstance.com")),
+                                  clientKey: "testKey",
+                                  connectionId: UUID())
         metrics.start()
 
         metrics.count(name: "irrelevant", enabled: true)
@@ -97,18 +97,18 @@ final class MetricsTests: XCTestCase {
     func testDisabledMetrics() throws {
         let fixedClock = { DateComponents(calendar: .current, timeZone: TimeZone(identifier: "UTC"), year: 2022, month: 12, day: 24, hour: 23, minute: 0, second: 0).date! }
 
-        let poster: Metrics.PosterHandler = { request, completionHandler in
-            completionHandler(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey : "should never get here"])))
+        let poster: Metrics.PosterHandler = { _, completionHandler in
+            completionHandler(.failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "should never get here"])))
         }
 
-        let metrics = Metrics(appName: "TestApp",
-                metricsInterval: 1,
-                clock: fixedClock,
-                disableMetrics: true,
-                poster: poster,
-                url: URL(string: "https://unleashinstance.com")!,
-                clientKey: "testKey",
-                connectionId: UUID())
+        let metrics = try Metrics(appName: "TestApp",
+                                  metricsInterval: 1,
+                                  clock: fixedClock,
+                                  disableMetrics: true,
+                                  poster: poster,
+                                  url: XCTUnwrap(URL(string: "https://unleashinstance.com")),
+                                  clientKey: "testKey",
+                                  connectionId: UUID())
         metrics.start()
 
         metrics.count(name: "irrelevant", enabled: true)
@@ -116,6 +116,4 @@ final class MetricsTests: XCTestCase {
 
         XCTAssertEqual(metrics.bucket.toggles, [:])
     }
-
-
 }

--- a/Tests/UnleashProxyClientSwiftTests/MockMetrics.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MockMetrics.swift
@@ -9,10 +9,10 @@ class MockMetrics: Metrics {
     }
 
     init(appName: String) {
-        let noOpPoster: Metrics.PosterHandler = { request, completionHandler in
+        let noOpPoster: Metrics.PosterHandler = { _, completionHandler in
             let response = HTTPURLResponse(url: URL(string: "https://irrelevant.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
             completionHandler(.success((Data(), response!)))
         }
-        super.init(appName: appName, metricsInterval: Double(15), clock: { return Date() }, disableMetrics: false, poster: noOpPoster, url: URL(string: "https://irrelevant.com")!, clientKey: "irrelevant", connectionId: UUID())
+        super.init(appName: appName, metricsInterval: Double(15), clock: { Date() }, disableMetrics: false, poster: noOpPoster, url: URL(string: "https://irrelevant.com")!, clientKey: "irrelevant", connectionId: UUID())
     }
 }

--- a/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
+++ b/Tests/UnleashProxyClientSwiftTests/MockPoller.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  MockPoller.swift
+//
 //
 //  Created by Fredrik Strand Oseberg on 27/05/2021.
 //
@@ -11,10 +11,10 @@ import Foundation
 class MockPollerSession: PollerSession {
     var data: Data?
     var response: URLResponse?
-    var error: Error?    
-    
+    var error: Error?
+
     var performRequestHandler: ((URLRequest) -> Void)?
-    
+
     init(data: Data? = nil, response: URLResponse? = nil, error: Error? = nil) {
         self.data = data
         self.response = response
@@ -41,23 +41,23 @@ public class MockDictionaryStorageProvider: StorageProvider {
     public func value(key: String) -> Toggle? {
         return storage[key]
     }
-    
+
     public func clear() {
         storage = [:]
     }
 }
 
 class MockPoller: Poller {
-    var dataGenerator: () -> [String: Toggle];
+    var dataGenerator: () -> [String: Toggle]
     var stubCompletionError: PollerError?
-    
+
     init(callback: @escaping () -> [String: Toggle], unleashUrl: URL, apiKey: String, session: PollerSession, appName: String, connectionId: UUID) {
-        self.dataGenerator = callback
+        dataGenerator = callback
         super.init(refreshInterval: 15, unleashUrl: unleashUrl, apiKey: apiKey, session: session, appName: appName, connectionId: connectionId)
     }
-    
-    override func getFeatures(context: Context, completionHandler: ((PollerError?) -> Void)? = nil) -> Void {
-        self.storageProvider = MockDictionaryStorageProvider(storage: dataGenerator())
+
+    override func getFeatures(context _: Context, completionHandler: ((PollerError?) -> Void)? = nil) {
+        storageProvider = MockDictionaryStorageProvider(storage: dataGenerator())
         completionHandler?(stubCompletionError)
     }
 }

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -1,8 +1,7 @@
-import XCTest
 @testable import UnleashProxyClientSwift
+import XCTest
 
 final class PollerTests: XCTestCase {
-
     private let unleashUrl = URL(string: "https://app.unleash-hosted.com/hosted/api/proxy")!
     private let apiKey = "SECRET"
     private let appName = "APPNAME"
@@ -21,21 +20,21 @@ final class PollerTests: XCTestCase {
                     featureEnabled: true,
                     payload: .init(type: "string", value: "FooBarBaz")
                 )
-            )
+            ),
         ]
-        
+
         let poller = createPoller(
             with: MockPollerSession(),
             bootstrap: .toggles(stubToggles)
         )
-        
+
         let foo = poller.getFeature(name: "Foo")
         let bar = poller.getFeature(name: "Bar")
-        
-        XCTAssertEqual(foo, stubToggles.first!)
-        XCTAssertEqual(bar, stubToggles.last!)
+
+        XCTAssertEqual(foo, stubToggles.first)
+        XCTAssertEqual(bar, stubToggles.last)
     }
-    
+
     func testWhenInitWithBootstrapFileThenAddToStore() {
         let poller = createPoller(
             with: MockPollerSession(),
@@ -50,7 +49,7 @@ final class PollerTests: XCTestCase {
             poller.getFeature(name: "no-variant"),
             Toggle(name: "no-variant", enabled: true)
         )
-        
+
         XCTAssertEqual(
             poller.getFeature(
                 name: "disabled-with-variant-disabled-no-payload"
@@ -65,7 +64,7 @@ final class PollerTests: XCTestCase {
                 )
             )
         )
-        
+
         XCTAssertEqual(
             poller.getFeature(
                 name: "enabled-with-variant-enabled-and-payload"
@@ -85,7 +84,7 @@ final class PollerTests: XCTestCase {
             )
         )
     }
-    
+
     func testTitleCaseEtagResponseHeader() {
         let response = mockResponse(headerFields: ["Etag": "W/\"77f-WboeNIYTrCbEJ+TK78VuhInQn2M\""])
         let data = stubData()
@@ -146,7 +145,7 @@ final class PollerTests: XCTestCase {
     }
 
     func testStartCompletesWithNetworkError() {
-        for statusCode in 400..<599 {
+        for statusCode in 400 ..< 599 {
             let response = mockResponse(statusCode: statusCode)
             let data = stubData()
             let session = MockPollerSession(data: data, response: response)
@@ -160,10 +159,10 @@ final class PollerTests: XCTestCase {
         }
     }
 
-    func testStartCompletesWithDecodingError() {
+    func testStartCompletesWithDecodingError() throws {
         let response = mockResponse()
         let stub: [String: Any] = ["toggles": [["foo": "bar", "baz": true]]]
-        let data = try! JSONSerialization.data(withJSONObject: stub, options: .prettyPrinted)
+        let data = try JSONSerialization.data(withJSONObject: stub, options: .prettyPrinted)
         let session = MockPollerSession(data: data, response: response)
         let poller = createPoller(with: session)
         let expectation = XCTestExpectation(description: "Expect .decoding PollerError.")
@@ -186,7 +185,7 @@ final class PollerTests: XCTestCase {
         }
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testCustomHeaders() {
         let customHeaders: [String: String] = ["X-Custom-Header": "CustomValue", "X-Another-Header": "AnotherValue", "unleash-appname": "Should be ignored", "Content-Type": "Should be ignored", "If-None-Match": "Should be ignored"]
         let response = mockResponse()
@@ -248,18 +247,18 @@ final class PollerTests: XCTestCase {
                     featureEnabled: true,
                     payload: .init(type: "string", value: "FooBarBaz")
                 )
-            )
+            ),
         ]
-        
+
         let poller = createPoller(with: MockPollerSession())
-        
+
         XCTAssertNil(poller.getFeature(name: "Foo"))
         XCTAssertNil(poller.getFeature(name: "Bar"))
-        
+
         poller.start(bootstrapping: stubToggles, context: Context())
-        
-        XCTAssertEqual(poller.getFeature(name: "Foo"), stubToggles.first!)
-        XCTAssertEqual(poller.getFeature(name: "Bar"), stubToggles.last!)
+
+        XCTAssertEqual(poller.getFeature(name: "Foo"), stubToggles.first)
+        XCTAssertEqual(poller.getFeature(name: "Bar"), stubToggles.last)
     }
 
     func testTimerNotInitializedWhenRefreshIntervalIsZero() {
@@ -271,7 +270,7 @@ final class PollerTests: XCTestCase {
             appName: appName,
             connectionId: connectionId
         )
-        
+
         XCTAssertNil(poller.timer, "Timer should not be initialized when refreshInterval is zero")
     }
 
@@ -291,7 +290,7 @@ final class PollerTests: XCTestCase {
         )
     }
 
-    private func mockResponse(statusCode: Int = 200, headerFields: [String : String]? = nil) -> URLResponse {
+    private func mockResponse(statusCode: Int = 200, headerFields: [String: String]? = nil) -> URLResponse {
         return HTTPURLResponse(url: unleashUrl, statusCode: statusCode, httpVersion: nil, headerFields: headerFields)!
     }
 
@@ -305,22 +304,22 @@ final class PollerTests: XCTestCase {
                 [
                     "name": "bar",
                     "enabled": false,
-                    "variant": ["name": "disabled", "enabled": false]
-                ]
-            ]
+                    "variant": ["name": "disabled", "enabled": false],
+                ],
+            ],
         ]
         return try! JSONSerialization.data(withJSONObject: stub, options: .prettyPrinted)
     }
 }
 
 private class MockCustomHeadersProvider: CustomHeadersProvider {
-    private let customHeaders: [String:String]
+    private let customHeaders: [String: String]
 
-    init(customHeaders: [String:String]) {
+    init(customHeaders: [String: String]) {
         self.customHeaders = customHeaders
     }
 
-    public func getCustomHeaders() -> [String: String] {
+    func getCustomHeaders() -> [String: String] {
         return customHeaders
     }
 }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashClientIntegrationTest.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashClientIntegrationTest.swift
@@ -1,11 +1,10 @@
-import XCTest
 @testable import UnleashProxyClientSwift
+import XCTest
 
 class UnleashIntegrationTests: XCTestCase {
-
     var unleashClient: UnleashProxyClientSwift.UnleashClientBase!
     let featureName = "enabled-feature"
-    
+
     override func setUpWithError() throws {
         unleashClient = UnleashProxyClientSwift.UnleashClientBase(
             unleashUrl: "https://sandbox.getunleash.io/enterprise/api/frontend",
@@ -22,7 +21,7 @@ class UnleashIntegrationTests: XCTestCase {
 
     func testUserJourneyHappyPath() {
         let expectation = self.expectation(description: "Waiting for client updates")
-        
+
         XCTAssertEqual(unleashClient.context.toMap(), ["environment": "default", "clientId": "disabled", "appName": "testIntegration", "sessionId": "1234"])
 
         unleashClient.subscribe(name: "ready", callback: {
@@ -32,33 +31,33 @@ class UnleashIntegrationTests: XCTestCase {
             XCTAssertNotNil(variant, "Variant should not be nil")
             XCTAssertFalse(variant.enabled, "Variant should be disabled")
 
-            self.unleashClient.updateContext(context: ["clientId": "enabled"]);
+            self.unleashClient.updateContext(context: ["clientId": "enabled"])
         })
-        
+
         unleashClient.subscribe(name: "update", callback: {
             XCTAssertTrue(self.unleashClient.isEnabled(name: self.featureName), "Feature should be enabled")
             let variant = self.unleashClient.getVariant(name: self.featureName)
             XCTAssertTrue(variant.enabled, "Variant should be enabled")
             XCTAssert(variant.name == "feature-variant")
-            
+
             expectation.fulfill()
-        });
+        })
 
         unleashClient.start()
         // Run isEnabled many times to trigger a data race when the poller is updating the data cache
         // This is to test that the poller is thread safe, and you can verify this by running the test with
         // swift test --sanitize=thread
-        for _ in 1...15000 {
+        for _ in 1 ... 15000 {
             let result = unleashClient.isEnabled(name: "dataRaceTest")
             XCTAssertFalse(result)
         }
 
         wait(for: [expectation], timeout: 5)
     }
-    
+
     func testUserJourneyHappyPathWithUnleashEvent() {
         let expectation = self.expectation(description: "Waiting for client updates")
-        
+
         XCTAssertEqual(unleashClient.context.toMap(), ["environment": "default", "clientId": "disabled", "appName": "testIntegration", "sessionId": "1234"])
 
         unleashClient.subscribe(.ready) {
@@ -68,15 +67,15 @@ class UnleashIntegrationTests: XCTestCase {
             XCTAssertNotNil(variant, "Variant should not be nil")
             XCTAssertFalse(variant.enabled, "Variant should be disabled")
 
-            self.unleashClient.updateContext(context: ["clientId": "enabled"]);
+            self.unleashClient.updateContext(context: ["clientId": "enabled"])
         }
-        
+
         unleashClient.subscribe(.update) {
             XCTAssertTrue(self.unleashClient.isEnabled(name: self.featureName), "Feature should be enabled")
             let variant = self.unleashClient.getVariant(name: self.featureName)
             XCTAssertTrue(variant.enabled, "Variant should be enabled")
             XCTAssert(variant.name == "feature-variant")
-            
+
             expectation.fulfill()
         }
 
@@ -84,7 +83,7 @@ class UnleashIntegrationTests: XCTestCase {
         // Run isEnabled many times to trigger a data race when the poller is updating the data cache
         // This is to test that the poller is thread safe, and you can verify this by running the test with
         // swift test --sanitize=thread
-        for _ in 1...15000 {
+        for _ in 1 ... 15000 {
             let result = unleashClient.isEnabled(name: "dataRaceTest")
             XCTAssertFalse(result)
         }

--- a/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashProxyClientSwiftTests.swift
@@ -1,124 +1,125 @@
-import XCTest
 @testable import UnleashProxyClientSwift
+import XCTest
 
 // MARK: UnleashProxyClient tests
+
 @available(iOS 13, *)
 final class unleash_proxy_client_swiftTests: XCTestCase {
     func testIsEnabled() {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             return generateBasicTestToggleMap()
         }
-        
+
         let unleash = setup(dataGenerator: dataGenerator)
-        
+
         XCTAssert(unleash.isEnabled(name: "Test") == true)
         XCTAssert(unleash.isEnabled(name: "TestTwo") == false)
         XCTAssert(unleash.isEnabled(name: "DoesNotExist") == false)
-        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: [:]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: [:]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: [:])];
-        XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics);
+        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: [:]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: [:]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: [:])]
+        XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics)
     }
-    
+
     func testGetVariant() {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             return generateTestToggleMapWithVariant()
         }
-        
+
         let unleash = setup(dataGenerator: dataGenerator)
-        
+
         let variantA = unleash.getVariant(name: "Test")
         let variantB = unleash.getVariant(name: "TestTwo")
         let variantC = unleash.getVariant(name: "DoesNotExist")
-        
+
         XCTAssert(variantA.name == "TestA" && variantA.enabled == true)
         XCTAssert(variantB.name == "TestB" && variantB.enabled == false)
         XCTAssert(variantC.name == "disabled") // change this to empty variant - name: disabled - enabled: false - empty payload
-        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])];
-        XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics);
-        
+        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])]
+        XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics)
     }
-    
+
     func testTimer() {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             return generateTestToggleMapWithVariant()
         }
-        
+
         let unleash = setup(dataGenerator: dataGenerator)
-        
+
         XCTAssert(unleash.poller.timer != nil)
     }
-    
+
     @MainActor
     func testTimerWithAsyncStart() async throws {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             generateTestToggleMapWithVariant()
         }
-        
+
         let mockedPoller = MockPollerSession()
         let unleash = try await setup(
             dataGenerator: dataGenerator,
             session: mockedPoller
         )
-        
+
         XCTAssert(unleash.poller.timer != nil)
     }
-    
+
     @MainActor
     func testGivenBootstrapWhenAsyncStartThenPassedToPoller() async throws {
         let stubToggle = Toggle(name: "Foo", enabled: false)
-        
+
         let unleash = try await setup(dataGenerator: { [:] })
-        
+
         XCTAssertNil(unleash.poller.getFeature(name: stubToggle.name))
-        
+
         try await unleash.start(bootstrap: .toggles([stubToggle]))
         XCTAssertEqual(
             unleash.poller.getFeature(name: "Foo"),
             Toggle(name: "Foo", enabled: false)
         )
     }
-    
-    func testUpdateContext() {
+
+    func testUpdateContext() throws {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             return generateTestToggleMapWithVariant()
         }
-        
+
         let stubPrintToConsoleAtStart = true
         let unleash = setup(
             dataGenerator: dataGenerator,
             printToConsole: stubPrintToConsoleAtStart
         )
-        
+
         var context: [String: String] = [:]
         context["userId"] = "uuid-123-test"
         context["sessionId"] = "uuid-234-test"
         unleash.updateContext(context: context)
-        
-        let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
-        
+
+        let url = try XCTUnwrap(unleash.poller.formatURL(context: unleash.context)?.absoluteString)
+
         XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid-123-test") && url.contains("environment=dev"))
         XCTAssertEqual(Printer.showPrintStatements, stubPrintToConsoleAtStart)
     }
-    
+
     @MainActor
     func testUpdateContextAsync() async throws {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             return generateTestToggleMapWithVariant()
         }
-        
+
         let unleash = try await setup(dataGenerator: dataGenerator)
-        
+
         var context: [String: String] = [:]
         context["userId"] = "uuid-123-test"
         context["sessionId"] = "uuid-234-test"
         try await unleash.updateContext(context: context)
-        
-        let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
-        
+
+        let url = try XCTUnwrap(unleash.poller.formatURL(context: unleash.context)?.absoluteString)
+
         XCTAssert(url.contains("appName=test") && url.contains("sessionId=uuid-234-test") && url.contains("userId=uuid-123-test") && url.contains("environment=dev"))
     }
 }
 
 // MARK: UnleashProxyClientBase tests
+
 final class unleash_proxy_client_base_swiftTests: XCTestCase {
     func testInitWithBootstrapAndNoPollerInitialisesPollerWithBootstrap() {
         let unleash = UnleashClientBase(
@@ -126,93 +127,92 @@ final class unleash_proxy_client_base_swiftTests: XCTestCase {
             clientKey: "SECRET",
             bootstrap: .toggles([Toggle(name: "Foo", enabled: false)])
         )
-        
+
         XCTAssertEqual(
             unleash.poller.getFeature(name: "Foo"),
             Toggle(name: "Foo", enabled: false)
         )
     }
-    
+
     func testGivenBootstrapWhenStartThenPassedToPoller() {
         let stubToggle = Toggle(name: "Foo", enabled: false)
-        
+
         let unleash = setupBase(dataGenerator: { [:] })
-        
+
         XCTAssertNil(unleash.poller.getFeature(name: stubToggle.name))
-        
+
         unleash.start(bootstrap: .toggles([stubToggle]))
         XCTAssertEqual(
             unleash.poller.getFeature(name: "Foo"),
             Toggle(name: "Foo", enabled: false)
         )
     }
-    
+
     func testIsEnabled() {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             generateBasicTestToggleMap()
         }
-        
+
         let unleash = setupBase(dataGenerator: dataGenerator)
-        
+
         XCTAssert(unleash.isEnabled(name: "Test") == true)
         XCTAssert(unleash.isEnabled(name: "TestTwo") == false)
         XCTAssert(unleash.isEnabled(name: "DoesNotExist") == false)
         let expectedToggleMetrics = [
             "TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: [:]),
             "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: [:]),
-            "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: [:])
+            "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: [:]),
         ]
         XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics)
     }
-    
+
     func testGetVariant() {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             return generateTestToggleMapWithVariant()
         }
-        
+
         let unleash = setupBase(dataGenerator: dataGenerator)
-        
+
         let variantA = unleash.getVariant(name: "Test")
         let variantB = unleash.getVariant(name: "TestTwo")
         let variantC = unleash.getVariant(name: "DoesNotExist")
-        
+
         XCTAssert(variantA.name == "TestA" && variantA.enabled == true)
         XCTAssert(variantB.name == "TestB" && variantB.enabled == false)
         XCTAssert(variantC.name == "disabled") // change this to empty variant - name: disabled - enabled: false - empty payload
-        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])];
-        XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics);
-        
+        let expectedToggleMetrics = ["TestTwo": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestB": 1]), "DoesNotExist": UnleashProxyClientSwift.ToggleMetrics(yes: 0, no: 1, variants: ["disabled": 1]), "Test": UnleashProxyClientSwift.ToggleMetrics(yes: 1, no: 0, variants: ["TestA": 1])]
+        XCTAssertEqual(unleash.metrics.bucket.toggles, expectedToggleMetrics)
     }
-    
+
     func testTimer() {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             return generateTestToggleMapWithVariant()
         }
-        
+
         let unleash = setupBase(dataGenerator: dataGenerator)
-        
+
         XCTAssert(unleash.poller.timer != nil)
     }
-    
-    func testUpdateContext() {
+
+    func testUpdateContext() throws {
         func dataGenerator() -> [String: UnleashProxyClientSwift.Toggle] {
             return generateTestToggleMapWithVariant()
         }
-        
+
         let unleash = setupBase(dataGenerator: dataGenerator)
-        
+
         var context: [String: String] = [:]
         context["userId"] = "uuid 123+test"
         context["sessionId"] = "uuid-234-test"
-        context["customContextKeyWorksButPreferProperties"] = "someValue";
+        context["customContextKeyWorksButPreferProperties"] = "someValue"
         var properties: [String: String] = [:]
-        properties["customKey"] = "customValue";
-        properties["custom+Key"] = "custom+Value";
-        
+        properties["customKey"] = "customValue"
+        properties["custom+Key"] = "custom+Value"
+
         unleash.updateContext(context: context, properties: properties)
-        
-        let url = unleash.poller.formatURL(context: unleash.context)!.absoluteString
-        
+
+        let url = try XCTUnwrap(unleash.poller.formatURL(context: unleash.context)?.absoluteString)
+
         XCTAssert(url.contains("appName=test"), url)
         XCTAssert(url.contains("sessionId=uuid-234-test"), url)
         XCTAssert(url.contains("userId=uuid%20123%2Btest"), url)

--- a/Tests/UnleashProxyClientSwiftTests/UnleashThreadSafetyTest.swift
+++ b/Tests/UnleashProxyClientSwiftTests/UnleashThreadSafetyTest.swift
@@ -1,8 +1,7 @@
-import XCTest
 @testable import UnleashProxyClientSwift
+import XCTest
 
 class UnleashThreadSafetyTest: XCTestCase {
-
     private var shouldRunIntensiveTest: Bool {
         return ProcessInfo.processInfo.environment["UNLEASH_THREAD_SAFETY_TEST"] == "1"
     }
@@ -31,7 +30,7 @@ class UnleashThreadSafetyTest: XCTestCase {
         client.start()
 
         // Run the test with high iteration count to increase chances of detecting race conditions
-        for _ in 0..<10000 {
+        for _ in 0 ..< 10000 {
             // Update context with userId and isAuthenticated properties
             client.updateContext(context: ["userId": "1"], properties: ["isAuthenticated": "true"]) { _ in }
 

--- a/Tests/UnleashProxyClientSwiftTests/testUtils.swift
+++ b/Tests/UnleashProxyClientSwiftTests/testUtils.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  testUtils.swift
+//
 //
 //  Created by Fredrik Strand Oseberg on 27/05/2021.
 //
@@ -19,11 +19,11 @@ func generateBasicTestToggleMap() -> [String: Toggle] {
         enabled: false,
         variant: Variant(name: "disabled", enabled: false, payload: nil)
     )
-    
+
     var toggleMap: [String: Toggle] = [:]
     toggleMap[toggleOne.name] = toggleOne
     toggleMap[toggleTwo.name] = toggleTwo
-    
+
     return toggleMap
 }
 
@@ -32,11 +32,11 @@ func generateTestToggleMapWithVariant() -> [String: Toggle] {
     let variantB = Variant(name: "TestB", enabled: false, payload: nil)
     let toggleOne = Toggle(name: "Test", enabled: true, variant: variantA)
     let toggleTwo = Toggle(name: "TestTwo", enabled: true, variant: variantB)
-    
+
     var toggleMap: [String: Toggle] = [:]
     toggleMap[toggleOne.name] = toggleOne
     toggleMap[toggleTwo.name] = toggleTwo
-    
+
     return toggleMap
 }
 


### PR DESCRIPTION
Noticed some linting issues and when run `swiftformat --lint .` there were tons of them reported.
So, applied `swiftformat .` on the source base to fix those.
After running it, `swiftformat --lint . ` reports clean 🟢 

To note: without a config, it uses SwiftFormat's defaults, so `swiftformat . `will reformat to those defaults — which is exactly what `--lint` was flagging, so the two agree, but with no extra rules that would make the code look 'prettier'.

We could add rules (on CI) and a .swiftformat file at the repo root with our chosen options — then both swiftformat and swiftformat --lint read it.  Same way as we do already on the provider