### PR TITLE
fix(poller): perform case-insensitive lookup for etag header and upda…

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/Poller.swift
@@ -203,7 +203,7 @@ public class Poller {
 
             var result: FeatureResponse?
 
-            if let newEtag = httpResponse.allHeaderFields["Etag"] as? String, !newEtag.isEmpty {
+            if let newEtag = httpResponse.value(forHTTPHeaderField: "Etag"), !newEtag.isEmpty {
                 lock.lock()
                 self.etag = newEtag
                 lock.unlock()

--- a/Tests/UnleashProxyClientSwiftTests/FakeHTTPResponse.swift
+++ b/Tests/UnleashProxyClientSwiftTests/FakeHTTPResponse.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Simulates a real network `HTTPURLResponse` by keeping header keys case-insensitive
+/// without Apple's default constructor key-canonicalization.
+final class FakeHTTPURLResponse: HTTPURLResponse, @unchecked Sendable {
+    private let rawHeaders: [String: String]
+
+    init(url: URL, statusCode: Int, headerFields: [String: String]) {
+        self.rawHeaders = headerFields
+        super.init(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var allHeaderFields: [AnyHashable: Any] {
+        return rawHeaders
+    }
+
+    override func value(forHTTPHeaderField field: String) -> String? {
+        return rawHeaders.first { key, _ in
+            key.caseInsensitiveCompare(field) == .orderedSame
+        }?.value
+    }
+}

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -290,8 +290,8 @@ final class PollerTests: XCTestCase {
         )
     }
 
-    private func mockResponse(statusCode: Int = 200, headerFields: [String: String]? = nil) -> URLResponse {
-        return HTTPURLResponse(url: unleashUrl, statusCode: statusCode, httpVersion: nil, headerFields: headerFields)!
+    private func mockResponse(statusCode: Int = 200, headerFields: [String: String] = [:]) -> URLResponse {
+        return FakeHTTPURLResponse(url: unleashUrl, statusCode: statusCode, headerFields: headerFields)
     }
 
     private func stubData() -> Data {


### PR DESCRIPTION
#136 

## Describe the bug

In `Poller.swift`, the ETag header was accessed directly from `HTTPURLResponse.allHeaderFielsusing` key indexing: `if let newTag = httpResponse.allHeaderFields["Etag"] as? string`.

Becase `allHeaderFields` returns a standard dictionary (`[AnyHashable: Any]`), indexing it with `["Etag"]` performs a case-sensitive lookup. This is also confirmed in the documentation in the discussion section (https://developer.apple.com/documentation/foundation/httpurlresponse/allheaderfields).

## About the changes

According to the HTTP specification (RFC 7230), HTTP header field names are case-insensitive. In production environments-especially over HTTP/2 or behind proxies/CDNs that lowercase header names (e.g., etag instead of Etag) `httpResponse.allHeaderFields["Etag"]` returns `nil`. As a result, the SDK fails to capture and store the updated etag, preventing If-None-Match caching from working properly.

Why existing unit tests missed this bug

The existing unit test `testLowerCaseEtagResponseHeader` appeared to pass becase it instantiate `HTTPURLResponse` directly via: `HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: ["etag": "..."])`.

Apple's `HTTPURLResponse` initializer canonicalizes dictionary keys in headerFields upon creation. This masked the bug in unit testing becase the mock response keys were normalized, hiding the fact that direct dictionary subscribing on `allHeaderFields["Etag"]` is case-sensitive.

## Proposed Fix

- Use `valuer(forHTTPHeaderFields:)` in `Poller.swift`:
Replace direct dictionary lookup with Foundation's standard case-insensitive header lookup method (https://developer.apple.com/documentation/foundation/httpurlresponse/value(forhttpheaderfield:)).

- Fix Unit Tests (`PollerTests.swift`):
Subclass/mock `HTTPURLResponse` in test suites so header keys retain their exact case without Foundation's automatic key normalization.

