### PR TITLE
fix(poller): resolve ios 12 compatibility issue with http header lookup

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/Poller.swift
@@ -203,7 +203,7 @@ public class Poller {
 
             var result: FeatureResponse?
 
-            if let newEtag = httpResponse.value(forHTTPHeaderField: "Etag"), !newEtag.isEmpty {
+            if let newEtag = value(forHTTPHeaderField: "Etag", in: httpResponse), !newEtag.isEmpty {
                 lock.lock()
                 self.etag = newEtag
                 lock.unlock()
@@ -247,6 +247,14 @@ public class Poller {
         return lowercasedHeader == "content-type" ||
             lowercasedHeader == "if-none-match" ||
             lowercasedHeader.hasPrefix("unleash-")
+    }
+
+    private func value(forHTTPHeaderField field: String, in response: HTTPURLResponse) -> String? {
+        if #available(iOS 13.0, *) {
+             return response.value(forHTTPHeaderField: field)
+        } else {
+            return (response.allHeaderFields as NSDictionary)[field] as? String
+        }
     }
 }
 


### PR DESCRIPTION
## About the changes

The native `value(forHTTPHeaderField:)`method on `HTTPURLResponse` is only available on iOS 13+ and macOS 10.15+. Because SPM package has a minimum target iOS 12, using it directly cause compatibility issues on older iOS devices despite compiling successfully for macOS.

This commit introduces a private wrapper that:
- Uses the modern `value(forHTTPHeaderField:)`on iOS 13+ and macOS (with available *).
-  Implements a safe fallback for iOS 12 by casting `alHeaderFields` to `NSDictionary`, preserving the native case-insensitive search behaviour for header like `Etag` vs `etag`.