### PR TITLE
chore: add minimum version CI gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,12 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: swift build
+  minimum_version_check:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build for iOS 12
+        run: xcodebuild build -scheme UnleashProxyClientSwift -destination 'generic/platform=iOS' IPHONEOS_DEPLOYMENT_TARGET=12.0
   test:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
Adds a CI gate to enforce minimum iOS version. I've checked that this fails correctly and then rebased it