### PR TITLE
fix: resolve ios 12 compatibility with header lookup

### DIFF
--- a/Sources/UnleashProxyClientSwift/Poller/Poller.swift
+++ b/Sources/UnleashProxyClientSwift/Poller/Poller.swift
@@ -203,7 +203,7 @@ public class Poller {
 
             var result: FeatureResponse?
 
-            if let newEtag = httpResponse.value(forHTTPHeaderField: "Etag"), !newEtag.isEmpty {
+            if let newEtag = value(forHTTPHeaderField: "Etag", in: httpResponse), !newEtag.isEmpty {
                 lock.lock()
                 self.etag = newEtag
                 lock.unlock()
@@ -247,6 +247,14 @@ public class Poller {
         return lowercasedHeader == "content-type" ||
             lowercasedHeader == "if-none-match" ||
             lowercasedHeader.hasPrefix("unleash-")
+    }
+
+    private func value(forHTTPHeaderField field: String, in response: HTTPURLResponse) -> String? {
+        // Once iOS 12 support is dropped, replace this with HTTPURLResponse.value(forHTTPHeaderField:).
+        return response.allHeaderFields.first { key, _ in
+            guard let header = key as? String else { return false }
+            return header.caseInsensitiveCompare(field) == .orderedSame
+        }?.value as? String
     }
 }
 

--- a/Tests/UnleashProxyClientSwiftTests/FakeHTTPResponse.swift
+++ b/Tests/UnleashProxyClientSwiftTests/FakeHTTPResponse.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Simulates a real network `HTTPURLResponse` by keeping header keys case-insensitive
+/// Simulates a real network `HTTPURLResponse` with raw header casing
 /// without Apple's default constructor key-canonicalization.
 final class FakeHTTPURLResponse: HTTPURLResponse, @unchecked Sendable {
     private let rawHeaders: [String: String]
@@ -16,11 +16,5 @@ final class FakeHTTPURLResponse: HTTPURLResponse, @unchecked Sendable {
 
     override var allHeaderFields: [AnyHashable: Any] {
         return rawHeaders
-    }
-
-    override func value(forHTTPHeaderField field: String) -> String? {
-        return rawHeaders.first { key, _ in
-            key.caseInsensitiveCompare(field) == .orderedSame
-        }?.value
     }
 }

--- a/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
+++ b/Tests/UnleashProxyClientSwiftTests/PollerTests.swift
@@ -107,6 +107,17 @@ final class PollerTests: XCTestCase {
         XCTAssertEqual(poller.etag, "W/\"710-wJiNH+MQpj0ruMo7n/9j36tB+Fg\"")
     }
 
+    func testRawEtagResponseHeaderLookupIsCaseInsensitive() {
+        let response = mockResponse(headerFields: ["ETAG": "W/\"710-wJiNH+MQpj0ruMo7n/9j36tB+Fg\""])
+        let data = stubData()
+        let session = MockPollerSession(data: data, response: response)
+        let poller = createPoller(with: session)
+
+        XCTAssertTrue(poller.etag.isEmpty)
+        poller.getFeatures(context: Context())
+        XCTAssertEqual(poller.etag, "W/\"710-wJiNH+MQpj0ruMo7n/9j36tB+Fg\"")
+    }
+
     func testEmptyEtagResponseHeader() {
         let response = mockResponse(headerFields: ["Etag": ""])
         let data = stubData()


### PR DESCRIPTION
Fixes iOS 12 compatibility after the ETag header lookup change in 2.5.1, fixes #140. Alternative to #141 - this preserves the case insensitive matching for iOS 12 as well - missed etags are a significant enough problem for Unleash that I think it's worth making it sure it works for arbitrary iOS versions even if the code is uglier.